### PR TITLE
CI: modify workflow build & Codes

### DIFF
--- a/.github/workflows/deploy-vm.yml
+++ b/.github/workflows/deploy-vm.yml
@@ -8,9 +8,7 @@ on:
         required: true
         type: choice
         options:
-        - ant-cli
         - embedder
-        - all
 
   push:
     branches:
@@ -19,24 +17,9 @@ on:
       - dev
       - "ci/*"
     paths:
-      - 'packages/ant-cli/**'
       - 'packages/ant-cli/src/periphery/integrations/vector-memory/embedder/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
 
 jobs:
-  # sonarqube:
-  #   name: SonarQube Analysis
-  #   runs-on: ["arc-runner-set"]
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-  #     - name: SonarQube Scan
-  #       uses: SonarSource/sonarqube-scan-action@v6
-  #       env:
-  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
   # ===========================================
   # 변경 감지
   # ===========================================
@@ -44,9 +27,7 @@ jobs:
     runs-on: [ax-ant-dev]
     if: github.event_name == 'push'
     outputs:
-      ant-cli-changed: ${{ steps.detect.outputs.ant-cli-changed }}
       embedder-changed: ${{ steps.detect.outputs.embedder-changed }}
-      root-package-changed: ${{ steps.detect.outputs.root-package-changed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,18 +41,7 @@ jobs:
           echo "$CHANGED_FILES"
           echo ""
           
-          # root package.json 또는 pnpm-lock.yaml 변경 시 전체 빌드
-          if echo "$CHANGED_FILES" | grep -qE "^(package\.json|pnpm-lock\.yaml)$"; then
-            echo "root-package-changed=true" >> $GITHUB_OUTPUT
-            echo "ant-cli-changed=true" >> $GITHUB_OUTPUT
-            echo "embedder-changed=true" >> $GITHUB_OUTPUT
-            echo "✅ Root package changed - ALL DEPLOY TRIGGERED!"
-            exit 0
-          fi
-          
-          echo "root-package-changed=false" >> $GITHUB_OUTPUT
-          
-          # embedder 변경 체크 (먼저 체크)
+          # embedder 변경 체크
           EMBEDDER_PATH="packages/ant-cli/src/periphery/integrations/vector-memory/embedder/"
           if echo "$CHANGED_FILES" | grep -q "^${EMBEDDER_PATH}"; then
             echo "embedder-changed=true" >> $GITHUB_OUTPUT
@@ -80,178 +50,6 @@ jobs:
             echo "embedder-changed=false" >> $GITHUB_OUTPUT
             echo "❌ embedder not changed"
           fi
-          
-          # ant-cli 변경 체크 (embedder 경로 제외)
-          ANT_CLI_CHANGES=$(echo "$CHANGED_FILES" | grep "^packages/ant-cli/" | grep -v "^${EMBEDDER_PATH}" || true)
-          if [ -n "$ANT_CLI_CHANGES" ]; then
-            echo "ant-cli-changed=true" >> $GITHUB_OUTPUT
-            echo "✅ ant-cli changed (excluding embedder)"
-          else
-            echo "ant-cli-changed=false" >> $GITHUB_OUTPUT
-            echo "❌ ant-cli not changed"
-          fi
-
-  # ===========================================
-  # ant-cli 배포
-  # ===========================================
-  deploy-ant-cli:
-    name: Deploy ant-cli
-    runs-on: [ax-ant-dev]
-    needs: [detect-changes]
-    if: |
-      always() && (
-        (github.event_name == 'workflow_dispatch' && (github.event.inputs.service == 'ant-cli' || github.event.inputs.service == 'all')) ||
-        (github.event_name == 'push' && needs.detect-changes.outputs.ant-cli-changed == 'true')
-      )
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Sync source to deploy directory
-        run: |
-          echo "📁 Syncing source to /cross/ant/ant..."
-          sudo mkdir -p /cross/ant/ant
-          sudo rsync -av --delete \
-            --exclude='node_modules' \
-            --exclude='.git' \
-            --exclude='dist' \
-            ./ /cross/ant/ant/
-          sudo chown -R cross:cross /cross/ant
-
-      - name: Generate docker-compose.yml
-        run: |
-          echo "📝 docker-compose.yml 생성 중..."
-          sudo mkdir -p /cross/ant/ant-cli
-          sudo tee /cross/ant/ant-cli/docker-compose.yml > /dev/null << 'EOFCOMPOSE'
-          services:
-            ant-cli:
-              build:
-                context: ../ant
-                dockerfile: packages/ant-cli/Dockerfile
-              image: ant-cli:latest
-              container_name: ant-cli
-              hostname: ant-cli
-              network_mode: host
-              restart: unless-stopped
-              env_file:
-                - .env
-              volumes:
-                - /var/run/docker.sock:/var/run/docker.sock
-                - /etc/localtime:/etc/localtime:ro
-                - /cross/workspaces:/data/workspaces:rw
-                - /cross/ide-homes:/data/ide-homes:rw
-              environment:
-                - NODE_ENV=production
-                - ANT_WORKSPACE_BASE_PATH=/data/workspaces
-                - ANT_IDE_HOME_BASE_PATH=/data/ide-homes
-              user: root
-              healthcheck:
-                test: ["CMD", "node", "-e", "require('http').get('http://localhost:4100/api/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))"]
-                interval: 30s
-                timeout: 10s
-                retries: 3
-                start_period: 30s
-          EOFCOMPOSE
-          sudo chown cross:cross /cross/ant/ant-cli/docker-compose.yml
-
-      - name: Generate .env file
-        run: |
-          echo "📝 .env 파일 생성 중..."
-          sudo tee /cross/ant/ant-cli/.env > /dev/null << EOF
-          # ===========================================
-          # ANT CLI 환경 변수 (GitHub Actions에서 자동 생성)
-          # ===========================================
-
-          # AI Model 설정
-          AI_MODEL_NAME=${{ vars.AI_MODEL_NAME || 'claude-sonnet-4-5-20250929' }}
-          AI_MODEL_PROVIDER=${{ vars.AI_MODEL_PROVIDER || 'anthropic' }}
-          AI_MODEL_TEMPERATURE=${{ vars.AI_MODEL_TEMPERATURE || '0.7' }}
-
-          # ANT Server 설정
-          ANT_CLI_PORT=${{ vars.ANT_CLI_PORT || '4100' }}
-          ANT_SERVER_MODE=${{ vars.ANT_SERVER_MODE || 'cloud' }}
-          ANT_WORKSPACE_BASE_PATH=${{ vars.ANT_WORKSPACE_BASE_PATH || '/cross/workspaces' }}
-          ANT_ENCRYPTION_KEY=${{ secrets.ANT_ENCRYPTION_KEY }}
-
-          # IDE 설정
-          ANT_IDE_HOME_BASE_PATH=${{ vars.ANT_IDE_HOME_BASE_PATH || '/cross/ide-homes' }}
-          ANT_IDE_HOSTNAME_MODE=${{ vars.ANT_IDE_HOSTNAME_MODE || 'user' }}
-          ANT_IDE_IMAGE=${{ vars.ANT_IDE_IMAGE || 'gitpod/openvscode-server:latest' }}
-          ANT_IDE_PORT_RANGE_START=${{ vars.ANT_IDE_PORT_RANGE_START || '30000' }}
-          ANT_IDE_PORT_RANGE_END=${{ vars.ANT_IDE_PORT_RANGE_END || '32767' }}
-
-          # LLM API Keys
-          ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
-          GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}
-
-          # Vector DB / Embedder
-          CHROMA_URL=${{ vars.CHROMA_URL || '' }}
-          EMBEDDER_URL=${{ vars.EMBEDDER_URL || '' }}
-
-          # Figma OAuth
-          FIGMA_CLIENT_ID=${{ vars.FIGMA_CLIENT_ID || '' }}
-          FIGMA_CLIENT_SECRET=${{ secrets.FIGMA_CLIENT_SECRET }}
-          FIGMA_REDIRECT_URI=${{ vars.FIGMA_REDIRECT_URI || '' }}
-
-          # Google OIDC (Cloud Auth)
-          GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
-          GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}
-          GOOGLE_REDIRECT_URI=${{ vars.GOOGLE_REDIRECT_URI || '' }}
-          FRONTEND_URL=${{ vars.FRONTEND_URL || '' }}
-          SKIP_AUTH_FOR_LOCALHOST=${{ vars.SKIP_AUTH_FOR_LOCALHOST || 'false' }}
-
-          # Git 설정
-          GIT_DEFAULT_BASE=${{ vars.GIT_DEFAULT_BASE || 'main' }}
-          GITHUB_TOKEN=${{ secrets.GH_TOKEN }}
-
-          # 기타
-          RECURSION_LIMIT=${{ vars.RECURSION_LIMIT || '800' }}
-          DEBUG_KANBAN=${{ vars.DEBUG_KANBAN || '0' }}
-          EOF
-          sudo chown cross:cross /cross/ant/ant-cli/.env
-          sudo chmod 600 /cross/ant/ant-cli/.env
-
-      - name: Build and Deploy ant-cli
-        working-directory: /cross/ant/ant-cli
-        run: |
-          echo "🔨 Docker 빌드 중..."
-          sudo docker compose build --no-cache ant-cli
-          
-          echo "🗑️ 기존 컨테이너 정리..."
-          sudo docker rm -f ant-cli 2>/dev/null || true
-          
-          echo "🔄 컨테이너 시작..."
-          sudo docker compose up -d ant-cli
-          
-          echo "🧹 오래된 이미지 정리..."
-          sudo docker image prune -f
-
-      - name: Health Check
-        run: |
-          echo "🏥 Health check 대기 중..."
-          sleep 15
-          
-          for i in {1..12}; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:4100/api/health || echo "000")
-            if [ "$STATUS" = "200" ]; then
-              echo "✅ Health check passed!"
-              exit 0
-            fi
-            echo "⏳ Waiting... ($i/12) - Status: $STATUS"
-            sleep 5
-          done
-          
-          echo "❌ Health check failed"
-          sudo docker compose -f /cross/ant/ant-cli/docker-compose.yml logs ant-cli
-          exit 1
-
-      - name: Show Status
-        if: always()
-        run: |
-          echo "📊 컨테이너 상태:"
-          sudo docker compose -f /cross/ant/ant-cli/docker-compose.yml ps
 
   # ===========================================
   # embedder 배포 (chroma-db VM runner에서 직접 빌드)
@@ -262,7 +60,7 @@ jobs:
     needs: [detect-changes]
     if: |
       always() && (
-        (github.event_name == 'workflow_dispatch' && (github.event.inputs.service == 'embedder' || github.event.inputs.service == 'all')) ||
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.service == 'embedder') ||
         (github.event_name == 'push' && needs.detect-changes.outputs.embedder-changed == 'true')
       )
 
@@ -343,22 +141,21 @@ jobs:
   # 배포 완료 알림 (Slack)
   # ===========================================
   notify:
-    needs: [deploy-ant-cli, deploy-embedder]
+    needs: [deploy-embedder]
     runs-on: [ax-ant-dev]
     if: always()
     steps:
       - name: Set deployment status
         id: status
         run: |
-          CLI_RESULT="${{ needs.deploy-ant-cli.result || 'skipped' }}"
           EMBEDDER_RESULT="${{ needs.deploy-embedder.result || 'skipped' }}"
           
           # 전체 결과 판단
-          if [[ "$CLI_RESULT" == "failure" ]] || [[ "$EMBEDDER_RESULT" == "failure" ]]; then
+          if [[ "$EMBEDDER_RESULT" == "failure" ]]; then
             echo "overall=failure" >> $GITHUB_OUTPUT
             echo "color=#FF0000" >> $GITHUB_OUTPUT
             echo "emoji=❌" >> $GITHUB_OUTPUT
-          elif [[ "$CLI_RESULT" == "success" ]] || [[ "$EMBEDDER_RESULT" == "success" ]]; then
+          elif [[ "$EMBEDDER_RESULT" == "success" ]]; then
             echo "overall=success" >> $GITHUB_OUTPUT
             echo "color=#36A64F" >> $GITHUB_OUTPUT
             echo "emoji=✅" >> $GITHUB_OUTPUT
@@ -369,7 +166,6 @@ jobs:
           fi
           
           # 결과 이모지 매핑
-          echo "cli_emoji=$([[ "$CLI_RESULT" == "success" ]] && echo "✅" || ([[ "$CLI_RESULT" == "failure" ]] && echo "❌" || echo "⏭️"))" >> $GITHUB_OUTPUT
           echo "embedder_emoji=$([[ "$EMBEDDER_RESULT" == "success" ]] && echo "✅" || ([[ "$EMBEDDER_RESULT" == "failure" ]] && echo "❌" || echo "⏭️"))" >> $GITHUB_OUTPUT
 
       - name: Send Slack Notification
@@ -404,10 +200,6 @@ jobs:
                 {
                   "type": "section",
                   "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*ant-cli:*\n${{ steps.status.outputs.cli_emoji }} ${{ needs.deploy-ant-cli.result || 'skipped' }}"
-                    },
                     {
                       "type": "mrkdwn",
                       "text": "*embedder:*\n${{ steps.status.outputs.embedder_emoji }} ${{ needs.deploy-embedder.result || 'skipped' }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ on:
         type: choice
         options:
           - ant-ui
+          - ant-cli
       git_ref:
         description: 'Git reference (commit SHA, branch, or tag) to deploy'
         required: false
@@ -38,6 +39,7 @@ on:
       - "ci/*"      # dev 환경 배포
     paths:
       - 'packages/ant-ui/**'
+      - 'packages/ant-cli/**'
       - 'package.json'
 
   repository_dispatch:
@@ -48,24 +50,15 @@ permissions:
   contents: read
 
 jobs:
-  # sonarqube:
-  #   name: SonarQube Analysis
-  #   runs-on: ["arc-runner-set"]
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-  #     - name: SonarQube Scan
-  #       uses: SonarSource/sonarqube-scan-action@v6
-  #       env:
-  #         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
+  # ===========================================
   # Detect changes in main, dev, stage, or ci branches
+  # ===========================================
   detect-changes:
     if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/dev') || startsWith(github.ref, 'refs/heads/stage') || startsWith(github.ref, 'refs/heads/ci/')) && github.event_name == 'push'
     runs-on: ["arc-runner-set"]
     outputs:
       ant-ui-changed: ${{ steps.detect.outputs.ant-ui-changed }}
+      ant-cli-changed: ${{ steps.detect.outputs.ant-cli-changed }}
       root-package-changed: ${{ steps.detect.outputs.root-package-changed }}
       deploy-all: ${{ steps.detect.outputs.root-package-changed == 'true' }}
     steps:
@@ -100,6 +93,15 @@ jobs:
             echo "ant-ui-changed=false" >> $GITHUB_OUTPUT
             echo "❌ No ant-ui files changed"
           fi
+          
+          # Check ant-cli changes
+          if echo "$CHANGED_FILES" | grep -q "^packages/ant-cli/"; then
+            echo "ant-cli-changed=true" >> $GITHUB_OUTPUT
+            echo "✅ ant-cli files changed"
+          else
+            echo "ant-cli-changed=false" >> $GITHUB_OUTPUT
+            echo "❌ No ant-cli files changed"
+          fi
 
   # ===========================================
   # Dev environment - ant-ui deployment (main, dev, ci/* branches)
@@ -117,6 +119,22 @@ jobs:
     secrets: inherit
 
   # ===========================================
+  # Dev environment - ant-cli deployment (main, dev, ci/* branches)
+  # ant-cli 이미지 하나로 ant-api, ant-job, ant-preview 모두 배포
+  # ===========================================
+  auto-ant-cli-dev-deploy:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.ant-cli-changed == 'true' && needs.detect-changes.outputs.root-package-changed != 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/dev') || startsWith(github.ref, 'refs/heads/ci/'))
+    uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
+    with:
+      environment: dev
+      env: dev
+      git_sha: ${{ github.sha }}
+      service_name: ant-cli
+      dockerfile: ./packages/ant-cli/Dockerfile
+    secrets: inherit
+
+  # ===========================================
   # Dev environment - Deploy all when root package.json changes (main, dev, ci/* branches)
   # ===========================================
   auto-all-ant-ui-dev-deploy:
@@ -129,6 +147,18 @@ jobs:
       git_sha: ${{ github.sha }}
       service_name: ant-ui
       dockerfile: ./packages/ant-ui/Dockerfile
+    secrets: inherit
+
+  auto-all-ant-cli-dev-deploy:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.root-package-changed == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/dev') || startsWith(github.ref, 'refs/heads/ci/'))
+    uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
+    with:
+      environment: dev
+      env: dev
+      git_sha: ${{ github.sha }}
+      service_name: ant-cli
+      dockerfile: ./packages/ant-cli/Dockerfile
     secrets: inherit
 
   # ===========================================
@@ -147,6 +177,21 @@ jobs:
     secrets: inherit
 
   # ===========================================
+  # Stage branch - ant-cli deployment
+  # ===========================================
+  auto-ant-cli-stage-deploy:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.ant-cli-changed == 'true' && needs.detect-changes.outputs.root-package-changed != 'true' && startsWith(github.ref, 'refs/heads/stage')
+    uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
+    with:
+      environment: stage
+      env: stage
+      git_sha: ${{ github.sha }}
+      service_name: ant-cli
+      dockerfile: ./packages/ant-cli/Dockerfile
+    secrets: inherit
+
+  # ===========================================
   # Stage branch - Deploy all when root package.json changes
   # ===========================================
   auto-all-ant-ui-stage-deploy:
@@ -161,11 +206,23 @@ jobs:
       dockerfile: ./packages/ant-ui/Dockerfile
     secrets: inherit
 
+  auto-all-ant-cli-stage-deploy:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.root-package-changed == 'true' && startsWith(github.ref, 'refs/heads/stage')
+    uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
+    with:
+      environment: stage
+      env: stage
+      git_sha: ${{ github.sha }}
+      service_name: ant-cli
+      dockerfile: ./packages/ant-cli/Dockerfile
+    secrets: inherit
+
   # ===========================================
-  # Manual deployment workflow
+  # Manual deployment workflow - ant-ui (dev, stage only)
   # ===========================================
   manual-ant-ui-deploy:
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.service == 'ant-ui'
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.service == 'ant-ui' && github.event.inputs.environment != 'prod'
     uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
     with:
       environment: ${{ github.event.inputs.environment }}
@@ -178,12 +235,28 @@ jobs:
     secrets: inherit
 
   # ===========================================
+  # Manual deployment workflow - ant-cli (dev, stage only)
+  # ===========================================
+  manual-ant-cli-deploy:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.service == 'ant-cli' && github.event.inputs.environment != 'prod'
+    uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
+    with:
+      environment: ${{ github.event.inputs.environment }}
+      env: ${{ github.event.inputs.environment }}
+      git_sha: ${{ github.sha }}
+      service_name: ant-cli
+      ticket_id: ${{ github.event.inputs.ticket_id || '' }}
+      git_ref: ${{ github.event.inputs.git_ref || '' }}
+      dockerfile: ./packages/ant-cli/Dockerfile
+    secrets: inherit
+
+  # ===========================================
   # Release (prod) deployment via repository_dispatch or workflow_dispatch
   # ===========================================
-  release-deploy:
+  release-deploy-ant-ui:
     if: >
       (github.event_name == 'repository_dispatch' && github.event.inputs.environment == 'prod') ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'prod' && github.event.inputs.service == '')
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'prod' && github.event.inputs.service == 'ant-ui')
     uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
     with:
       environment: prod
@@ -193,4 +266,19 @@ jobs:
       ticket_id: ${{ github.event.inputs.ticket_id || '' }}
       git_ref: ${{ github.event.inputs.git_ref || '' }}
       dockerfile: ./packages/ant-ui/Dockerfile
+    secrets: inherit
+
+  release-deploy-ant-cli:
+    if: >
+      (github.event_name == 'repository_dispatch' && github.event.inputs.environment == 'prod') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'prod' && github.event.inputs.service == 'ant-cli')
+    uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
+    with:
+      environment: prod
+      env: prod
+      git_sha: ${{ github.sha }}
+      service_name: ant-cli
+      ticket_id: ${{ github.event.inputs.ticket_id || '' }}
+      git_ref: ${{ github.event.inputs.git_ref || '' }}
+      dockerfile: ./packages/ant-cli/Dockerfile
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+#### KubernetesIDEOrchestrator Integration
+- **cloud-ide.routes.ts**: Replace `IDEService` (Docker) with `IDEOrchestratorPort` interface
+- **cloud-ide.routes.ts**: Add `host` field to responses for K8s Pod IP support
+- **cloud-ide.routes.ts**: Update `getDirectUrl()` to handle K8s mode (returns proxy URL)
+- **cloud-ide.routes.ts**: Add runtime info in debug response (`ideRuntime: kubernetes/docker`)
+- **RouteConfigurator.ts**: Use `InfrastructureFactory.getIDEOrchestrator()` instead of `deps.ideService`
+- **KubernetesIDEOrchestrator.ts**: Add `readServiceAccountCACert()` for in-cluster TLS verification
+- **KubernetesIDEOrchestrator.ts**: Add `getPodIfExists()` helper method
+- **KubernetesIDEOrchestrator.ts**: Add `waitForPodDeletion()` for graceful pod recreation
+- **KubernetesIDEOrchestrator.ts**: Add `createInstanceResult()` for reusing existing pods
+- **KubernetesIDEOrchestrator.ts**: Add `deletionTimestamp` to `K8sMetadata` type
+
+### Changed
+
+#### InfrastructureFactory
+- Move dependency check inside else block - K8s mode doesn't require `PortManager`/`PortRegistry`
+
+#### KubernetesIDEOrchestrator
+- Rewrite `k8sRequest()` to use `https` module with ServiceAccount CA certificate (instead of `fetch`)
+- Handle Pod lifecycle states:
+  - `Running`: reuse existing pod
+  - `Terminating` (deletionTimestamp set): wait for deletion then recreate
+  - `Failed`/`Pending`: delete and recreate
+- Handle Service 409 Conflict error (already exists) gracefully
+
+### Fixed
+
+#### Redis/ElastiCache TLS with Custom CNAME
+- **RedisStateStore.ts**: Skip TLS hostname verification for ElastiCache Serverless with custom CNAME
+- **BullMQJobQueue.ts**: Add TLS `checkServerIdentity` bypass for custom CNAME
+- **JobWorker.ts**: Add TLS `checkServerIdentity` bypass for BullMQ Worker
+
+#### KubernetesIDEOrchestrator
+- **KubernetesIDEOrchestrator**: Fix TLS certificate verification error (`unable to verify the first certificate`) by using ServiceAccount CA cert from `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
+- **KubernetesIDEOrchestrator**: Fix 409 Conflict error when Pod is being deleted by waiting for deletion completion
+- **KubernetesIDEOrchestrator**: Add request timeout (10s) and debug logs to `k8sRequest()` and `waitForPodReady()`
+- **KubernetesIDEOrchestrator**: Add 5s timeout to `stateStore.registerIDE()` to prevent hanging if Redis is slow
+- **GitStatusService**: Handle `dubious ownership` error gracefully for shared EFS volumes (returns empty status instead of infinite retry)
+- **ideProxy.ts**: Support K8s mode by proxying to Pod IP instead of localhost
+- **baseProxy.ts**: Add `targetHost` to `ProxyContext` and `getHost()` method for K8s support
+- **RouteConfigurator.ts**: Call `ideOrchestrator.startIdleCheck()` for auto-cleanup of idle IDE pods
+- **KubernetesIDEOrchestrator**: Add detailed logging for `deleteResources()` operations
+
+---
+
+## Comparison: `cloud-scalability` → `ci/modify-cloud-build`
+
+| File | Changes |
+|------|---------|
+| `cloud-ide.routes.ts` | `IDEService` → `IDEOrchestratorPort`, add `host` field, K8s proxy URL support |
+| `RouteConfigurator.ts` | Use `getIDEOrchestrator()` from factory |
+| `InfrastructureFactory.ts` | K8s mode skips PortManager dependency check |
+| `KubernetesIDEOrchestrator.ts` | +181 lines: TLS fix, Pod lifecycle handling, helper methods |

--- a/packages/ant-cli/src/infrastructure/adapters/InfrastructureFactory.ts
+++ b/packages/ant-cli/src/infrastructure/adapters/InfrastructureFactory.ts
@@ -228,12 +228,9 @@ export class InfrastructureFactory {
    * - Without: LocalIDEOrchestrator (local Docker)
    */
   getIDEOrchestrator(): IDEOrchestratorPort {
-    if (!this.portManager || !this.portRegistry) {
-      throw new Error('Dependencies not set. Call setDependencies() first.');
-    }
-    
     if (!this.ideOrchestrator) {
       if (this.config.k8sNamespace) {
+        // K8s mode: doesn't need PortManager/PortRegistry
         this.ideOrchestrator = new KubernetesIDEOrchestrator(
           { namespace: this.config.k8sNamespace },
           this.getStateStore()
@@ -242,6 +239,10 @@ export class InfrastructureFactory {
           component: 'InfrastructureFactory'
         });
       } else {
+        // Docker mode: requires PortManager/PortRegistry
+        if (!this.portManager || !this.portRegistry) {
+          throw new Error('Dependencies not set for LocalIDEOrchestrator. Call setDependencies() first.');
+        }
         this.ideOrchestrator = new LocalIDEOrchestrator(
           this.portManager,
           this.portRegistry

--- a/packages/ant-cli/src/infrastructure/ide/KubernetesIDEOrchestrator.ts
+++ b/packages/ant-cli/src/infrastructure/ide/KubernetesIDEOrchestrator.ts
@@ -39,6 +39,7 @@ interface K8sMetadata {
   namespace: string;
   labels: Record<string, string>;
   annotations?: Record<string, string>;
+  deletionTimestamp?: string;  // Set when pod is being deleted
 }
 
 interface K8sPod {
@@ -128,9 +129,11 @@ export class KubernetesIDEOrchestrator implements IDEOrchestratorPort {
 
   /**
    * Create instance key
+   * Format: tenantId:projectId (3 parts total: org:user:project)
+   * Note: feature is excluded - one pod per user per project
    */
-  private createInstanceKey(tenantId: string, projectId: string, feature: string): string {
-    return `${tenantId}:${projectId}:${feature}`;
+  private createInstanceKey(tenantId: string, projectId: string): string {
+    return `${tenantId}:${projectId}`;
   }
 
   /**
@@ -141,46 +144,84 @@ export class KubernetesIDEOrchestrator implements IDEOrchestratorPort {
   }
 
   /**
-   * Make K8s API request
+   * Make K8s API request using https module with ServiceAccount CA certificate
    */
   private async k8sRequest<T>(
     path: string,
     method: 'GET' | 'POST' | 'DELETE' = 'GET',
-    body?: any
+    body?: any,
+    timeoutMs: number = 10000
   ): Promise<T> {
-    // Determine API URL
-    const apiUrl = this.options.kubeApiUrl || 
-      process.env.KUBERNETES_SERVICE_HOST 
-        ? `https://${process.env.KUBERNETES_SERVICE_HOST}:${process.env.KUBERNETES_SERVICE_PORT}`
-        : 'http://localhost:8001';  // kubectl proxy
-
-    // Get token
-    const token = this.options.kubeToken ||
-      (process.env.KUBERNETES_SERVICE_HOST 
-        ? await this.readServiceAccountToken()
-        : undefined);
-
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json'
-    };
-    if (token) {
-      headers['Authorization'] = `Bearer ${token}`;
-    }
-
-    const url = `${apiUrl}${path}`;
+    const https = await import('https');
+    const http = await import('http');
     
-    const response = await fetch(url, {
-      method,
-      headers,
-      body: body ? JSON.stringify(body) : undefined
+    // Determine API URL
+    const isInCluster = !!process.env.KUBERNETES_SERVICE_HOST;
+    const apiHost = this.options.kubeApiUrl?.replace(/^https?:\/\//, '').split(':')[0] ||
+      process.env.KUBERNETES_SERVICE_HOST || 'localhost';
+    const apiPort = this.options.kubeApiUrl?.split(':')[2] ||
+      process.env.KUBERNETES_SERVICE_PORT || '8001';
+
+    // Get token and CA cert (in-cluster)
+    const token = this.options.kubeToken || await this.readServiceAccountToken();
+    const caCert = isInCluster ? await this.readServiceAccountCACert() : undefined;
+    
+    console.log(`[KubernetesIDEOrchestrator] K8s API: ${method} ${path} (host=${apiHost}, port=${apiPort}, hasCaCert=${!!caCert}, hasToken=${!!token})`);
+    
+    // Use https for in-cluster, http for local kubectl proxy
+    const useHttps = isInCluster || !!this.options.kubeApiUrl;
+    const protocol = useHttps ? https : http;
+
+    return new Promise((resolve, reject) => {
+      const requestBody = body ? JSON.stringify(body) : undefined;
+      
+      const options: https.RequestOptions = {
+        hostname: apiHost,
+        port: parseInt(apiPort, 10),
+        path,
+        method,
+        timeout: timeoutMs,
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+          ...(requestBody ? { 'Content-Length': Buffer.byteLength(requestBody) } : {})
+        },
+        ...(caCert ? { ca: caCert } : {})
+      };
+      
+      const req = protocol.request(options, (res) => {
+        let data = '';
+        res.on('data', (chunk) => data += chunk);
+        res.on('end', () => {
+          console.log(`[KubernetesIDEOrchestrator] K8s API response: ${res.statusCode} (${data.length} bytes)`);
+          if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+            try {
+              resolve(JSON.parse(data));
+            } catch {
+              resolve(data as any);
+            }
+          } else {
+            reject(new Error(`K8s API error: ${res.statusCode} - ${data}`));
+          }
+        });
+      });
+
+      req.on('timeout', () => {
+        console.log(`[KubernetesIDEOrchestrator] K8s API TIMEOUT: ${method} ${path}`);
+        req.destroy();
+        reject(new Error(`K8s API request timeout: ${method} ${path}`));
+      });
+
+      req.on('error', (err) => {
+        console.log(`[KubernetesIDEOrchestrator] K8s API ERROR: ${err.message}`);
+        reject(err);
+      });
+      
+      if (requestBody) {
+        req.write(requestBody);
+      }
+      req.end();
     });
-
-    if (!response.ok) {
-      const error = await response.text();
-      throw new Error(`K8s API error: ${response.status} - ${error}`);
-    }
-
-    return await response.json();
   }
 
   /**
@@ -191,6 +232,25 @@ export class KubernetesIDEOrchestrator implements IDEOrchestratorPort {
       const fs = await import('fs');
       return fs.readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/token', 'utf8');
     } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Read service account CA certificate (in-cluster)
+   */
+  private async readServiceAccountCACert(): Promise<string | undefined> {
+    try {
+      const fs = await import('fs');
+      const cert = fs.readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/ca.crt', 'utf8');
+      logger.debug(`Loaded ServiceAccount CA cert (${cert.length} bytes)`, {
+        component: 'KubernetesIDEOrchestrator'
+      });
+      return cert;
+    } catch (err: any) {
+      logger.warn(`Failed to read ServiceAccount CA cert: ${err.message}`, {
+        component: 'KubernetesIDEOrchestrator'
+      });
       return undefined;
     }
   }
@@ -281,35 +341,75 @@ export class KubernetesIDEOrchestrator implements IDEOrchestratorPort {
   async start(params: IDEParams): Promise<IDEStartResult> {
     const { userContext, projectId, workspacePath, feature = 'main' } = params;
     const tenantId = `${userContext.organizationId}:${userContext.userId}`;
-    const instanceKey = this.createInstanceKey(tenantId, projectId, feature);
+    const instanceKey = this.createInstanceKey(tenantId, projectId);
     const resourceName = this.createResourceName(instanceKey);
 
-    logger.info(`Starting K8s IDE: ${instanceKey}`, {
+    console.log(`[KubernetesIDEOrchestrator] ▶ START request received: ${instanceKey}`);
+    logger.info(`[KubernetesIDEOrchestrator] Starting K8s IDE: ${instanceKey}`, {
       component: 'KubernetesIDEOrchestrator',
       organizationId: userContext.organizationId,
       userId: userContext.userId,
-      projectId
+      projectId,
+      resourceName,
+      namespace: this.options.namespace
     });
 
     try {
+      // Check if pod already exists
+      console.log(`[KubernetesIDEOrchestrator] Checking if pod exists: ${resourceName}`);
+      const existingPod = await this.getPodIfExists(resourceName);
+      console.log(`[KubernetesIDEOrchestrator] Pod exists check result: ${existingPod ? 'exists' : 'not found'}`);
+      
+      if (existingPod) {
+        // Pod exists - check status
+        console.log(`[KubernetesIDEOrchestrator] Pod status: phase=${existingPod.status?.phase}, deletionTimestamp=${existingPod.metadata?.deletionTimestamp || 'none'}`);
+        
+        if (existingPod.metadata?.deletionTimestamp) {
+          // Pod is being deleted - wait for deletion then recreate
+          console.log(`[KubernetesIDEOrchestrator] Pod is being deleted, waiting...`);
+          await this.waitForPodDeletion(resourceName);
+        } else if (existingPod.status?.phase === 'Running') {
+          // Pod is running - return existing instance
+          console.log(`[KubernetesIDEOrchestrator] Pod already running, calling createInstanceResult()`);
+          return this.createInstanceResult(existingPod, tenantId, userContext, projectId, feature, instanceKey);
+        } else {
+          // Pod exists but not running (Failed, Pending, etc) - delete and recreate
+          console.log(`[KubernetesIDEOrchestrator] Pod exists but not running (${existingPod.status?.phase}), recreating`);
+          await this.deleteResources(resourceName);
+          await this.waitForPodDeletion(resourceName);
+        }
+      }
+
       // Create Pod
+      console.log(`[KubernetesIDEOrchestrator] Creating Pod: ${resourceName} in namespace ${this.options.namespace}`);
       const podSpec = this.createPodSpec(instanceKey, resourceName, workspacePath, userContext);
       await this.k8sRequest(
         `/api/v1/namespaces/${this.options.namespace}/pods`,
         'POST',
         podSpec
       );
+      console.log(`[KubernetesIDEOrchestrator] Pod created: ${resourceName}`);
 
-      // Create Service
+      // Create Service (ignore if already exists)
+      console.log(`[KubernetesIDEOrchestrator] Creating Service: ${resourceName}`);
       const serviceSpec = this.createServiceSpec(instanceKey, resourceName);
-      await this.k8sRequest(
-        `/api/v1/namespaces/${this.options.namespace}/services`,
-        'POST',
-        serviceSpec
-      );
+      try {
+        await this.k8sRequest(
+          `/api/v1/namespaces/${this.options.namespace}/services`,
+          'POST',
+          serviceSpec
+        );
+        console.log(`[KubernetesIDEOrchestrator] Service created: ${resourceName}`);
+      } catch (e: any) {
+        // Ignore 409 conflict for service (already exists)
+        if (!e.message?.includes('409')) throw e;
+        console.log(`[KubernetesIDEOrchestrator] Service already exists: ${resourceName}`);
+      }
 
       // Wait for pod to be ready (simplified)
+      console.log(`[KubernetesIDEOrchestrator] Waiting for Pod to be ready: ${resourceName}`);
       await this.waitForPodReady(resourceName);
+      console.log(`[KubernetesIDEOrchestrator] Pod is ready: ${resourceName}`);
 
       // Get pod info
       const pod = await this.k8sRequest<K8sPod>(
@@ -341,11 +441,13 @@ export class KubernetesIDEOrchestrator implements IDEOrchestratorPort {
         lastAccessedAt: new Date()
       };
 
+      console.log(`[KubernetesIDEOrchestrator] ✅ IDE started successfully: ${instanceKey} (host=${instance.host})`);
       return {
         success: true,
         instance
       };
     } catch (error: any) {
+      console.log(`[KubernetesIDEOrchestrator] ❌ Failed to start IDE: ${instanceKey} - ${error.message}`);
       logger.error(`Failed to start K8s IDE: ${instanceKey}`, {
         component: 'KubernetesIDEOrchestrator'
       }, error);
@@ -365,24 +467,42 @@ export class KubernetesIDEOrchestrator implements IDEOrchestratorPort {
   /**
    * Wait for pod to become ready
    */
-  private async waitForPodReady(resourceName: string, timeoutMs: number = 60000): Promise<void> {
+  private async waitForPodReady(resourceName: string, timeoutMs: number = 120000): Promise<void> {
     const startTime = Date.now();
     
+    console.log(`[KubernetesIDEOrchestrator] Waiting for Pod to be ready: ${resourceName} (timeout: ${timeoutMs / 1000}s)`);
+    
+    let lastPhase = '';
     while (Date.now() - startTime < timeoutMs) {
       try {
         const pod = await this.k8sRequest<K8sPod>(
           `/api/v1/namespaces/${this.options.namespace}/pods/${resourceName}`
         );
 
-        if (pod.status?.phase === 'Running') {
+        const phase = pod.status?.phase || 'Unknown';
+        const containerStatuses = pod.status?.containerStatuses?.[0];
+        const waiting = containerStatuses?.state?.waiting;
+        
+        // Log only when phase changes or every 10 seconds
+        const elapsed = Date.now() - startTime;
+        if (phase !== lastPhase || elapsed % 10000 < 2000) {
+          const waitReason = waiting ? ` (${waiting.reason}: ${waiting.message || 'no message'})` : '';
+          console.log(`[KubernetesIDEOrchestrator] Pod ${resourceName}: phase=${phase}${waitReason} (${Math.round(elapsed / 1000)}s)`);
+          lastPhase = phase;
+        }
+
+        if (phase === 'Running') {
+          console.log(`[KubernetesIDEOrchestrator] Pod is ready: ${resourceName}`);
           return;
         }
 
-        if (pod.status?.phase === 'Failed') {
-          throw new Error('Pod failed to start');
+        if (phase === 'Failed') {
+          const reason = containerStatuses?.state?.terminated?.reason || 'Unknown';
+          throw new Error(`Pod failed to start: ${reason}`);
         }
       } catch (error: any) {
         if (!error.message.includes('404')) {
+          console.log(`[KubernetesIDEOrchestrator] Error checking pod: ${error.message}`);
           throw error;
         }
       }
@@ -390,26 +510,143 @@ export class KubernetesIDEOrchestrator implements IDEOrchestratorPort {
       await new Promise(resolve => setTimeout(resolve, 2000));
     }
 
-    throw new Error('Pod startup timeout');
+    throw new Error(`Pod ${resourceName} startup timeout after ${timeoutMs}ms`);
+  }
+
+  /**
+   * Get pod if it exists, returns null if not found
+   */
+  private async getPodIfExists(resourceName: string): Promise<K8sPod | null> {
+    try {
+      return await this.k8sRequest<K8sPod>(
+        `/api/v1/namespaces/${this.options.namespace}/pods/${resourceName}`
+      );
+    } catch (error: any) {
+      if (error.message?.includes('404')) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Wait for pod to be fully deleted
+   */
+  private async waitForPodDeletion(resourceName: string, timeoutMs: number = 30000): Promise<void> {
+    const startTime = Date.now();
+    
+    while (Date.now() - startTime < timeoutMs) {
+      const pod = await this.getPodIfExists(resourceName);
+      if (!pod) {
+        return; // Pod deleted
+      }
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+    
+    throw new Error(`Timeout waiting for pod ${resourceName} to be deleted`);
+  }
+
+  /**
+   * Create instance result from existing pod
+   */
+  private async createInstanceResult(
+    pod: K8sPod,
+    tenantId: string,
+    userContext: UserContext,
+    projectId: string,
+    feature: string,
+    instanceKey: string
+  ): Promise<IDEStartResult> {
+    console.log(`[KubernetesIDEOrchestrator] createInstanceResult() called for pod ${pod.metadata.name}, IP=${pod.status?.podIP}`);
+    
+    // Update last access time in state store (with timeout to prevent hanging)
+    // Note: registerIDE expects (tenantId=org, userId, projectId, feature) - NOT org:user combined
+    console.log(`[KubernetesIDEOrchestrator] Calling stateStore.registerIDE()...`);
+    try {
+      const registerPromise = this.stateStore.registerIDE(
+        userContext.organizationId,  // org only, not org:user
+        userContext.userId,
+        projectId,
+        feature,
+        8080,
+        pod.status?.podIP || pod.metadata.name
+      );
+      
+      // 5 second timeout for Redis operation
+      const timeoutPromise = new Promise<void>((_, reject) => {
+        setTimeout(() => reject(new Error('registerIDE timeout')), 5000);
+      });
+      
+      await Promise.race([registerPromise, timeoutPromise]);
+      console.log(`[KubernetesIDEOrchestrator] stateStore.registerIDE() completed`);
+    } catch (err: any) {
+      // Don't fail the whole operation if state store fails
+      console.log(`[KubernetesIDEOrchestrator] ⚠️ stateStore.registerIDE() failed: ${err.message} - continuing anyway`);
+    }
+
+    const instance: IDEInstance = {
+      instanceId: pod.metadata.name,
+      host: pod.status?.podIP || pod.metadata.name,
+      port: 8080,
+      url: `/ide/${instanceKey}`,
+      workspacePath: '/workspace',
+      status: 'running',
+      tenantId,
+      userId: userContext.userId,
+      projectId,
+      feature,
+      createdAt: new Date(),
+      lastAccessedAt: new Date()
+    };
+
+    console.log(`[KubernetesIDEOrchestrator] ✅ createInstanceResult() returning success, host=${instance.host}, port=${instance.port}`);
+    return {
+      success: true,
+      instance
+    };
   }
 
   /**
    * Delete pod and service
    */
   private async deleteResources(resourceName: string): Promise<void> {
+    logger.info(`Deleting K8s resources: ${resourceName}`, {
+      component: 'KubernetesIDEOrchestrator'
+    });
+
     try {
       await this.k8sRequest(
         `/api/v1/namespaces/${this.options.namespace}/pods/${resourceName}`,
         'DELETE'
       );
-    } catch {}
+      logger.info(`Pod ${resourceName} delete request sent`, {
+        component: 'KubernetesIDEOrchestrator'
+      });
+    } catch (err: any) {
+      // 404 is ok (already deleted)
+      if (!err.message?.includes('404')) {
+        logger.warn(`Failed to delete pod ${resourceName}: ${err.message}`, {
+          component: 'KubernetesIDEOrchestrator'
+        });
+      }
+    }
 
     try {
       await this.k8sRequest(
         `/api/v1/namespaces/${this.options.namespace}/services/${resourceName}`,
         'DELETE'
       );
-    } catch {}
+      logger.info(`Service ${resourceName} delete request sent`, {
+        component: 'KubernetesIDEOrchestrator'
+      });
+    } catch (err: any) {
+      // 404 is ok (already deleted)
+      if (!err.message?.includes('404')) {
+        logger.warn(`Failed to delete service ${resourceName}: ${err.message}`, {
+          component: 'KubernetesIDEOrchestrator'
+        });
+      }
+    }
   }
 
   async stop(
@@ -417,7 +654,7 @@ export class KubernetesIDEOrchestrator implements IDEOrchestratorPort {
     projectId: string,
     feature: string = 'main'
   ): Promise<{ success: boolean; message?: string }> {
-    const instanceKey = this.createInstanceKey(tenantId, projectId, feature);
+    const instanceKey = this.createInstanceKey(tenantId, projectId);
     const resourceName = this.createResourceName(instanceKey);
 
     logger.info(`Stopping K8s IDE: ${instanceKey}`, {
@@ -448,7 +685,7 @@ export class KubernetesIDEOrchestrator implements IDEOrchestratorPort {
     projectId: string,
     feature: string = 'main'
   ): Promise<IDEInstance | null> {
-    const instanceKey = this.createInstanceKey(tenantId, projectId, feature);
+    const instanceKey = this.createInstanceKey(tenantId, projectId);
     const resourceName = this.createResourceName(instanceKey);
 
     try {

--- a/packages/ant-cli/src/infrastructure/queue/BullMQJobQueue.ts
+++ b/packages/ant-cli/src/infrastructure/queue/BullMQJobQueue.ts
@@ -76,12 +76,21 @@ export class BullMQJobQueue implements JobQueuePort {
     logger.info(`BullMQ job queue initialized: ${queueName}`, { component: 'BullMQJobQueue' });
   }
 
-  private parseRedisUrl(url: string): { host: string; port: number; password?: string } {
+  private parseRedisUrl(url: string): { host: string; port: number; password?: string; tls?: { rejectUnauthorized?: boolean; checkServerIdentity?: () => undefined } } {
     const parsed = new URL(url);
+    const isTLS = url.startsWith('rediss://');
+    
     return {
       host: parsed.hostname,
       port: parseInt(parsed.port) || 6379,
-      password: parsed.password || undefined
+      password: parsed.password || undefined,
+      // TLS options for ElastiCache with custom CNAME
+      // Skip hostname verification since ElastiCache cert is for *.serverless.*.cache.amazonaws.com
+      ...(isTLS && {
+        tls: {
+          checkServerIdentity: () => undefined
+        }
+      })
     };
   }
 

--- a/packages/ant-cli/src/infrastructure/state/RedisStateStore.ts
+++ b/packages/ant-cli/src/infrastructure/state/RedisStateStore.ts
@@ -67,8 +67,20 @@ export class RedisStateStore implements StateStorePort, PortRegistryPort {
   constructor(options: RedisStateStoreOptions) {
     this.keyPrefix = options.keyPrefix || '';
     
+    // Check if TLS is enabled (rediss:// URL)
+    const isTLS = options.url.startsWith('rediss://');
+    
+    // TLS options for ElastiCache with custom CNAME
+    // Skip hostname verification since ElastiCache cert is for *.serverless.*.cache.amazonaws.com
+    const tlsOptions = isTLS ? {
+      tls: {
+        checkServerIdentity: () => undefined  // Skip hostname verification
+      }
+    } : {};
+    
     // Main connection for commands
     this.redis = new Redis(options.url, {
+      ...tlsOptions,
       maxRetriesPerRequest: options.maxRetriesPerRequest ?? 3,
       retryStrategy: (times: number) => {
         if (times > 10) {
@@ -81,6 +93,7 @@ export class RedisStateStore implements StateStorePort, PortRegistryPort {
 
     // Separate connection for pub/sub (required by Redis)
     this.subscriber = new Redis(options.url, {
+      ...tlsOptions,
       maxRetriesPerRequest: options.maxRetriesPerRequest ?? 3
     });
 
@@ -404,6 +417,8 @@ export class RedisStateStore implements StateStorePort, PortRegistryPort {
     const portKey = this.createPortKey(tenantId, userId, projectId, feature);
     const key = this.key(KEYS.IDE, portKey);
     
+    console.log(`[RedisStateStore] registerIDE() called: key=${key}, host=${host}, port=${port}`);
+    
     const mapping: PortMapping = {
       tenantId,
       userId,
@@ -418,8 +433,9 @@ export class RedisStateStore implements StateStorePort, PortRegistryPort {
     const pipeline = this.redis.pipeline();
     pipeline.set(key, JSON.stringify(mapping), 'EX', TTL.PORT_MAPPING);
     pipeline.sadd(this.key(KEYS.IDE_LIST), portKey);
-    await pipeline.exec();
+    const result = await pipeline.exec();
 
+    console.log(`[RedisStateStore] registerIDE() completed: key=${key}, result=${JSON.stringify(result)}`);
     logger.info(`IDE registered: ${portKey} → ${host}:${port}`, { component: 'RedisStateStore' });
   }
 
@@ -431,13 +447,18 @@ export class RedisStateStore implements StateStorePort, PortRegistryPort {
   ): Promise<PortMapping | null> {
     const portKey = this.createPortKey(tenantId, userId, projectId, feature);
     const key = this.key(KEYS.IDE, portKey);
+    
+    console.log(`[RedisStateStore] getIDE() called: key=${key}`);
+    
     const data = await this.redis.get(key);
 
     if (!data) {
+      console.log(`[RedisStateStore] getIDE() not found: key=${key}`);
       return null;
     }
 
     const mapping: PortMapping = JSON.parse(data);
+    console.log(`[RedisStateStore] getIDE() found: key=${key}, host=${mapping.host}, port=${mapping.port}`);
     
     // Update last accessed
     mapping.lastAccessedAt = new Date();

--- a/packages/ant-cli/src/infrastructure/worker/JobWorker.ts
+++ b/packages/ant-cli/src/infrastructure/worker/JobWorker.ts
@@ -60,12 +60,21 @@ export class JobWorker {
   /**
    * Parse Redis URL for BullMQ connection
    */
-  private parseRedisUrl(url: string): { host: string; port: number; password?: string } {
+  private parseRedisUrl(url: string): { host: string; port: number; password?: string; tls?: { rejectUnauthorized?: boolean; checkServerIdentity?: () => undefined } } {
     const parsed = new URL(url);
+    const isTLS = url.startsWith('rediss://');
+    
     return {
       host: parsed.hostname,
       port: parseInt(parsed.port) || 6379,
-      password: parsed.password || undefined
+      password: parsed.password || undefined,
+      // TLS options for ElastiCache with custom CNAME
+      // Skip hostname verification since ElastiCache cert is for *.serverless.*.cache.amazonaws.com
+      ...(isTLS && {
+        tls: {
+          checkServerIdentity: () => undefined
+        }
+      })
     };
   }
 

--- a/packages/ant-cli/src/periphery/adapters/http/express/config/RouteConfigurator.ts
+++ b/packages/ant-cli/src/periphery/adapters/http/express/config/RouteConfigurator.ts
@@ -173,10 +173,20 @@ export class RouteConfigurator {
 
   /**
    * Setup Cloud IDE routes (both modes)
+   * Uses KubernetesIDEOrchestrator in cloud mode (ANT_K8S_NAMESPACE set),
+   * LocalIDEOrchestrator (Docker) otherwise
    */
   private setupCloudIDERoutes(app: Express): void {
+    console.log(`[RouteConfigurator] Setting up Cloud IDE routes (ANT_K8S_NAMESPACE=${process.env.ANT_K8S_NAMESPACE || 'not set'})`);
+    
+    const ideOrchestrator = getInfrastructureFactory().getIDEOrchestrator();
+    console.log(`[RouteConfigurator] IDE Orchestrator type: ${ideOrchestrator.constructor.name}`);
+    
+    // Start idle check for auto-cleanup of unused IDE instances
+    ideOrchestrator.startIdleCheck();
+    
     const cloudIDERoutes = createCloudIDERoutes(
-      this.deps.ideService, 
+      ideOrchestrator, 
       this.deps.workspaceResolver
     );
     app.use('/api/cloud-ide', cloudIDERoutes);

--- a/packages/ant-cli/src/periphery/adapters/http/middleware/baseProxy.ts
+++ b/packages/ant-cli/src/periphery/adapters/http/middleware/baseProxy.ts
@@ -28,6 +28,7 @@ export interface ProxyContext {
   res: ExpressResponse;
   serverKeyParts: ServerKeyParts;
   targetPort: number;
+  targetHost: string;  // 'localhost' for Docker, Pod IP for K8s
   targetPath: string;
 }
 
@@ -55,6 +56,14 @@ export abstract class BaseProxyMiddleware {
    * Get port for the given server key parts
    */
   protected abstract getPort(parts: ServerKeyParts): Promise<number | null>;
+
+  /**
+   * Get host for the given server key parts (default: localhost)
+   * Override for K8s mode to return Pod IP
+   */
+  protected async getHost(_parts: ServerKeyParts): Promise<string> {
+    return 'localhost';
+  }
 
   /**
    * Update last access time for the service
@@ -159,6 +168,9 @@ export abstract class BaseProxyMiddleware {
         return;
       }
 
+      // Get host (localhost for Docker, Pod IP for K8s)
+      const host = await this.getHost(parts);
+
       // Strip prefix from path
       const prefix = `${this.pathPrefix}/${serverKey}`;
       let targetPath = req.url;
@@ -171,6 +183,7 @@ export abstract class BaseProxyMiddleware {
         res,
         serverKeyParts: parts,
         targetPort: port,
+        targetHost: host,
         targetPath
       };
 
@@ -182,8 +195,8 @@ export abstract class BaseProxyMiddleware {
    * Proxy the request to the target server
    */
   protected async proxyRequest(context: ProxyContext): Promise<void> {
-    const { req, res, targetPort, targetPath } = context;
-    const targetUrl = `http://localhost:${targetPort}${targetPath}`;
+    const { req, res, targetPort, targetHost, targetPath } = context;
+    const targetUrl = `http://${targetHost}:${targetPort}${targetPath}`;
 
     logger.debug(`Proxy to ${targetUrl}`, { component: this.componentName });
 
@@ -202,7 +215,7 @@ export abstract class BaseProxyMiddleware {
             method: req.method,
             headers: {
               ...req.headers,
-              host: `localhost:${targetPort}`,
+              host: `${targetHost}:${targetPort}`,
               'accept-encoding': 'identity',
               'if-none-match': undefined,
               'if-modified-since': undefined

--- a/packages/ant-cli/src/periphery/adapters/http/middleware/ideProxy.ts
+++ b/packages/ant-cli/src/periphery/adapters/http/middleware/ideProxy.ts
@@ -72,6 +72,33 @@ class IDEProxyMiddlewareImpl extends BaseProxyMiddleware {
     );
   }
 
+  /**
+   * Get host for IDE (localhost for Docker, Pod IP for K8s)
+   */
+  protected async getHost(parts: ServerKeyParts): Promise<string> {
+    try {
+      // Use StateStorePort to get full PortMapping with host
+      const { getInfrastructureFactory } = await import('../../../../infrastructure/adapters/InfrastructureFactory');
+      const stateStore = getInfrastructureFactory().getStateStore();
+      const mapping = await stateStore.getIDE(
+        parts.tenantId,
+        parts.userId,
+        parts.projectId,
+        parts.feature || 'main'
+      );
+      
+      if (mapping?.host) {
+        console.log(`[IDEProxy] Host from StateStore: ${mapping.host}`);
+        return mapping.host;
+      }
+    } catch (err) {
+      console.log(`[IDEProxy] Failed to get IDE host from StateStore: ${err}`);
+    }
+    
+    console.log(`[IDEProxy] Falling back to localhost`);
+    return 'localhost';
+  }
+
   protected async updateLastAccess(parts: ServerKeyParts): Promise<void> {
     await this.portRegistry.updateLastAccess(
       parts.tenantId,
@@ -153,12 +180,26 @@ export function createIDEWebSocketHandler(portRegistry: PortRegistryPort, pathPr
     const [tenantId, userId, projectId] = parts;
     const feature = 'main';  // IDE always uses 'main' (project-level)
 
-    // Lookup port
+    // Lookup port and host
     const port = await portRegistry.getIDEPort(tenantId, userId, projectId, feature);
     if (!port) {
       logger.warn(`No IDE port for WS: ${serverKey}`, { component: 'IDEProxy' });
       socket.destroy();
       return;
+    }
+
+    // Get host (localhost for Docker, Pod IP for K8s)
+    let host = 'localhost';
+    try {
+      const { getInfrastructureFactory } = await import('../../../../infrastructure/adapters/InfrastructureFactory');
+      const stateStore = getInfrastructureFactory().getStateStore();
+      const mapping = await stateStore.getIDE(tenantId, userId, projectId, feature);
+      if (mapping?.host) {
+        host = mapping.host;
+        console.log(`[IDEProxy WS] Host from StateStore: ${host}`);
+      }
+    } catch (err) {
+      console.log(`[IDEProxy WS] Failed to get IDE host: ${err}`);
     }
 
     // Update last access
@@ -168,11 +209,11 @@ export function createIDEWebSocketHandler(portRegistry: PortRegistryPort, pathPr
     const targetPath = url.slice(`${pathPrefix}/${serverKey}`.length) || '/';
     req.url = targetPath;
     
-    logger.debug(`WS proxy to localhost:${port}${targetPath}`, { component: 'IDEProxy' });
+    logger.debug(`WS proxy to ${host}:${port}${targetPath}`, { component: 'IDEProxy' });
 
     // Proxy the WebSocket connection
     proxy.ws(req, socket, head, {
-      target: `ws://localhost:${port}`
+      target: `ws://${host}:${port}`
     });
   };
 }

--- a/packages/ant-cli/src/periphery/adapters/http/routes/cloud-ide.routes.ts
+++ b/packages/ant-cli/src/periphery/adapters/http/routes/cloud-ide.routes.ts
@@ -2,24 +2,32 @@
  * Cloud IDE Routes
  * 
  * Endpoints for managing cloud-based IDE containers (code-server)
+ * 
+ * In cloud mode (ANT_K8S_NAMESPACE set): Uses KubernetesIDEOrchestrator
+ * In local mode: Uses LocalIDEOrchestrator (Docker)
  */
 
 import { Router, Request, Response } from 'express';
-import { IDEService } from '../../ide/IDEService';
+import { IDEOrchestratorPort, IDEParams } from '../../../../core/ports/ideOrchestrator';
 import { UserContext } from '../../../../core/types/user';
 import { extractUserContext } from './helpers/userContext';
 import * as path from 'path';
 import { logger } from '../../../../utils/logger';
 
-export function createCloudIDERoutes(ideService: IDEService, workspaceResolver: any): Router {
+export function createCloudIDERoutes(ideOrchestrator: IDEOrchestratorPort, workspaceResolver: any): Router {
   const router = Router();
 
-  function getDirectUrl(req: Request, port: number): string {
+  function getDirectUrl(req: Request, host: string, port: number): string {
     const forwardedProto = (req.headers['x-forwarded-proto'] as string) || req.protocol || 'http';
     const forwardedHost = (req.headers['x-forwarded-host'] as string) || (req.headers.host as string) || 'localhost';
     const hostWithoutPort = forwardedHost.includes(':') ? forwardedHost.split(':')[0] : forwardedHost;
     // For local dev, the IDE container is bound to a host port. Direct access is simplest.
-    return `${forwardedProto}://${hostWithoutPort}:${port}`;
+    // For K8s, we use the service/pod name
+    if (host === 'localhost' || host.startsWith('127.')) {
+      return `${forwardedProto}://${hostWithoutPort}:${port}`;
+    }
+    // K8s mode - return proxy URL
+    return `${forwardedProto}://${forwardedHost}/ide`;
   }
   
   /**
@@ -31,6 +39,8 @@ export function createCloudIDERoutes(ideService: IDEService, workspaceResolver: 
       const { projectId, featureName } = req.body;
       const userContext: UserContext = req.body.userContext || extractUserContext(req);
       
+      console.log(`[CloudIDERoutes] POST /cloud-ide/start - projectId=${projectId}, user=${userContext?.userId}`);
+      
       if (!projectId) {
         return res.status(400).json({ error: 'projectId is required' });
       }
@@ -40,22 +50,45 @@ export function createCloudIDERoutes(ideService: IDEService, workspaceResolver: 
       // ✅ IDE should only see codebase (project-level isolation of codebase in IDE)
       const workspacePath = path.join(projectPath, 'codebase');
       
-      // Start IDE
-      const instance = await ideService.startIDE(userContext, projectId, workspacePath, featureName || 'main');
+      const tenantId = `${userContext.organizationId}:${userContext.userId}`;
+      
+      console.log(`[CloudIDERoutes] Calling ideOrchestrator.start() for ${tenantId}:${projectId}`);
+      
+      // Start IDE using orchestrator
+      const params: IDEParams = {
+        tenantId,
+        userId: userContext.userId,
+        projectId,
+        feature: featureName || 'main',
+        workspacePath,
+        userContext
+      };
+      
+      const result = await ideOrchestrator.start(params);
+      console.log(`[CloudIDERoutes] ideOrchestrator.start() result: success=${result.success}`);
+      
+      if (!result.success || !result.instance) {
+        return res.status(500).json({ 
+          success: false, 
+          error: result.error || 'Failed to start IDE' 
+        });
+      }
+      
+      const instance = result.instance;
       
       res.json({
         success: true,
         instance: {
           url: instance.url,
-          directUrl: getDirectUrl(req, instance.port),
+          directUrl: getDirectUrl(req, instance.host, instance.port),
           port: instance.port,
+          host: instance.host,
           status: instance.status,
-          workspacePath: instance.workspacePath  // ✅ Docker 내부 경로 반환
+          workspacePath: instance.workspacePath
         },
         debug: {
-          ideImage: process.env.ANT_IDE_IMAGE || 'gitpod/openvscode-server:latest',
-          workspaceMode: 'project', // ✅ fixed (always /{projectId})
-          hostnameMode: process.env.ANT_IDE_HOSTNAME_MODE || 'user'
+          ideRuntime: process.env.ANT_K8S_NAMESPACE ? 'kubernetes' : 'docker',
+          namespace: process.env.ANT_K8S_NAMESPACE || 'N/A'
         }
       });
       
@@ -79,8 +112,24 @@ export function createCloudIDERoutes(ideService: IDEService, workspaceResolver: 
       const projectPath = workspaceResolver.getProjectPath(userContext, projectId);
       const workspacePath = path.join(projectPath, 'codebase');
 
-      const instance = await ideService.startIDE(userContext, projectId, workspacePath, featureName);
-      res.redirect(302, getDirectUrl(req, instance.port));
+      const tenantId = `${userContext.organizationId}:${userContext.userId}`;
+      
+      const params: IDEParams = {
+        tenantId,
+        userId: userContext.userId,
+        projectId,
+        feature: featureName,
+        workspacePath,
+        userContext
+      };
+      
+      const result = await ideOrchestrator.start(params);
+      
+      if (!result.success || !result.instance) {
+        return res.status(500).json({ error: result.error || 'Failed to start IDE' });
+      }
+      
+      res.redirect(302, getDirectUrl(req, result.instance.host, result.instance.port));
     } catch (error: any) {
       logger.warn(`Open failed: ${error.message}`, { component: 'CloudIDERoutes', projectId: req.params?.projectId, featureName: req.query?.feature as any }, error);
       res.status(500).json({ error: error.message });
@@ -102,9 +151,9 @@ export function createCloudIDERoutes(ideService: IDEService, workspaceResolver: 
       
       const tenantId = `${userContext.organizationId}:${userContext.userId}`;
       
-      await ideService.stopIDE(tenantId, projectId, featureName || 'main');
+      const result = await ideOrchestrator.stop(tenantId, projectId, featureName || 'main');
       
-      res.json({ success: true });
+      res.json({ success: result.success, message: result.message });
       
     } catch (error: any) {
       logger.warn(`Stop failed: ${error.message}`, { component: 'CloudIDERoutes', projectId: req.body?.projectId, featureName: req.body?.featureName }, error);
@@ -124,7 +173,7 @@ export function createCloudIDERoutes(ideService: IDEService, workspaceResolver: 
       
       const tenantId = `${userContext.organizationId}:${userContext.userId}`;
       
-      const instance = await ideService.getIDEStatus(tenantId, projectId, featureName);
+      const instance = await ideOrchestrator.getStatus(tenantId, projectId, featureName);
       
       if (!instance) {
         return res.json({ running: false });
@@ -135,6 +184,7 @@ export function createCloudIDERoutes(ideService: IDEService, workspaceResolver: 
         instance: {
           url: instance.url,
           port: instance.port,
+          host: instance.host,
           status: instance.status,
           createdAt: instance.createdAt,
           lastAccessedAt: instance.lastAccessedAt
@@ -151,9 +201,9 @@ export function createCloudIDERoutes(ideService: IDEService, workspaceResolver: 
    * GET /cloud-ide/list
    * List all running cloud IDEs
    */
-  router.get('/list', (req: Request, res: Response) => {
+  router.get('/list', async (req: Request, res: Response) => {
     try {
-      const instances = ideService.listIDEs();
+      const instances = await ideOrchestrator.list();
       
       res.json({
         instances: instances.map(i => ({
@@ -161,6 +211,7 @@ export function createCloudIDERoutes(ideService: IDEService, workspaceResolver: 
           projectId: i.projectId,
           url: i.url,
           port: i.port,
+          host: i.host,
           status: i.status,
           createdAt: i.createdAt,
           lastAccessedAt: i.lastAccessedAt
@@ -175,4 +226,3 @@ export function createCloudIDERoutes(ideService: IDEService, workspaceResolver: 
   
   return router;
 }
-

--- a/packages/ant-cli/src/periphery/adapters/http/services/GitService/status/index.ts
+++ b/packages/ant-cli/src/periphery/adapters/http/services/GitService/status/index.ts
@@ -91,6 +91,7 @@ export class StatusService {
     behind: number;
     currentBranch?: string;
     isGitInitialized?: boolean;
+    error?: string;
   }> {
     try {
       const projectPath = this.workspaceResolver.getProjectPath(userContext, projectId);
@@ -131,7 +132,27 @@ export class StatusService {
         };
       }
 
-      const status = await git.status();
+      let status;
+      try {
+        status = await git.status();
+      } catch (statusError: any) {
+        // Handle "dubious ownership" error gracefully (shared EFS volumes)
+        if (statusError.message?.includes('dubious ownership')) {
+          console.warn(`[GitStatusService] Dubious ownership error for ${codebasePath} - returning empty status`);
+          return {
+            hasChanges: false,
+            staged: [],
+            unstaged: [],
+            untracked: [],
+            ahead: 0,
+            behind: 0,
+            currentBranch: undefined,
+            isGitInitialized: true,
+            error: 'dubious_ownership'
+          };
+        }
+        throw statusError;
+      }
       
       const staged = status.staged || [];
       const modified = status.modified || [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,8 +160,6 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
-  packages/ant-ide: {}
-
   packages/ant-ui:
     dependencies:
       '@radix-ui/react-slot':


### PR DESCRIPTION
# Changelog

All notable changes to this project will be documented in this file.

## [Unreleased]

### Added

#### KubernetesIDEOrchestrator Integration
- **cloud-ide.routes.ts**: Replace `IDEService` (Docker) with `IDEOrchestratorPort` interface
- **cloud-ide.routes.ts**: Add `host` field to responses for K8s Pod IP support
- **cloud-ide.routes.ts**: Update `getDirectUrl()` to handle K8s mode (returns proxy URL)
- **cloud-ide.routes.ts**: Add runtime info in debug response (`ideRuntime: kubernetes/docker`)
- **RouteConfigurator.ts**: Use `InfrastructureFactory.getIDEOrchestrator()` instead of `deps.ideService`
- **KubernetesIDEOrchestrator.ts**: Add `readServiceAccountCACert()` for in-cluster TLS verification
- **KubernetesIDEOrchestrator.ts**: Add `getPodIfExists()` helper method
- **KubernetesIDEOrchestrator.ts**: Add `waitForPodDeletion()` for graceful pod recreation
- **KubernetesIDEOrchestrator.ts**: Add `createInstanceResult()` for reusing existing pods
- **KubernetesIDEOrchestrator.ts**: Add `deletionTimestamp` to `K8sMetadata` type

### Changed

#### InfrastructureFactory
- Move dependency check inside else block - K8s mode doesn't require `PortManager`/`PortRegistry`

#### KubernetesIDEOrchestrator
- Rewrite `k8sRequest()` to use `https` module with ServiceAccount CA certificate (instead of `fetch`)
- Handle Pod lifecycle states:
  - `Running`: reuse existing pod
  - `Terminating` (deletionTimestamp set): wait for deletion then recreate
  - `Failed`/`Pending`: delete and recreate
- Handle Service 409 Conflict error (already exists) gracefully

### Fixed

#### Redis/ElastiCache TLS with Custom CNAME
- **RedisStateStore.ts**: Skip TLS hostname verification for ElastiCache Serverless with custom CNAME
- **BullMQJobQueue.ts**: Add TLS `checkServerIdentity` bypass for custom CNAME
- **JobWorker.ts**: Add TLS `checkServerIdentity` bypass for BullMQ Worker

#### KubernetesIDEOrchestrator
- **KubernetesIDEOrchestrator**: Fix TLS certificate verification error (`unable to verify the first certificate`) by using ServiceAccount CA cert from `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
- **KubernetesIDEOrchestrator**: Fix 409 Conflict error when Pod is being deleted by waiting for deletion completion
- **KubernetesIDEOrchestrator**: Add request timeout (10s) and debug logs to `k8sRequest()` and `waitForPodReady()`
- **KubernetesIDEOrchestrator**: Add 5s timeout to `stateStore.registerIDE()` to prevent hanging if Redis is slow
- **GitStatusService**: Handle `dubious ownership` error gracefully for shared EFS volumes (returns empty status instead of infinite retry)
- **ideProxy.ts**: Support K8s mode by proxying to Pod IP instead of localhost
- **baseProxy.ts**: Add `targetHost` to `ProxyContext` and `getHost()` method for K8s support
- **RouteConfigurator.ts**: Call `ideOrchestrator.startIdleCheck()` for auto-cleanup of idle IDE pods
- **KubernetesIDEOrchestrator**: Add detailed logging for `deleteResources()` operations

---

## Comparison: `cloud-scalability` → `ci/modify-cloud-ide-build`

| File | Changes |
|------|---------|
| `cloud-ide.routes.ts` | `IDEService` → `IDEOrchestratorPort`, add `host` field, K8s proxy URL support |
| `RouteConfigurator.ts` | Use `getIDEOrchestrator()` from factory |
| `InfrastructureFactory.ts` | K8s mode skips PortManager dependency check |
| `KubernetesIDEOrchestrator.ts` | +181 lines: TLS fix, Pod lifecycle handling, helper methods |
