### PR TITLE
Ci/add preview build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ on:
         options:
           - ant-ui
           - ant-cli
+          - ant-cli-preview
       git_ref:
         description: 'Git reference (commit SHA, branch, or tag) to deploy'
         required: false
@@ -121,7 +122,7 @@ jobs:
 
   # ===========================================
   # Dev environment - ant-cli deployment (main, dev, ci/* branches)
-  # ant-cli 이미지 하나로 ant-api, ant-job, ant-preview 모두 배포
+  # ant-cli 이미지: ant-api, ant-job 워커용 (언어 런타임 없는 경량 이미지)
   # ===========================================
   auto-ant-cli-dev-deploy:
     needs: detect-changes
@@ -133,6 +134,28 @@ jobs:
       git_sha: ${{ github.sha }}
       service_name: ant-cli
       dockerfile: ./packages/ant-cli/Dockerfile
+    secrets: inherit
+
+  # ===========================================
+  # Dev environment - ant-cli-preview deployment (main, dev, ci/* branches)
+  # ant-cli-preview 이미지: preview 워커 전용 (멀티 언어 런타임 포함)
+  # ===========================================
+  auto-ant-cli-preview-dev-deploy:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.ant-cli-changed == 'true' && needs.detect-changes.outputs.root-package-changed != 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/dev') || github.ref == 'refs/heads/cloud-scalability' || startsWith(github.ref, 'refs/heads/ci/'))
+    uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
+    with:
+      environment: dev
+      env: dev
+      git_sha: ${{ github.sha }}
+      service_name: ant-cli-preview
+      dockerfile: ./packages/ant-cli/Dockerfile
+      target: preview
+      build_args: |
+        GO_VERSION=${{ vars.PREVIEW_GO_VERSION }}
+        PYTHON_VERSION=${{ vars.PREVIEW_PYTHON_VERSION }}
+        RUST_VERSION=${{ vars.PREVIEW_RUST_VERSION }}
+        JAVA_VERSION=${{ vars.PREVIEW_JAVA_VERSION }}
     secrets: inherit
 
   # ===========================================
@@ -160,6 +183,24 @@ jobs:
       git_sha: ${{ github.sha }}
       service_name: ant-cli
       dockerfile: ./packages/ant-cli/Dockerfile
+    secrets: inherit
+
+  auto-all-ant-cli-preview-dev-deploy:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.root-package-changed == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/dev') || github.ref == 'refs/heads/cloud-scalability' || startsWith(github.ref, 'refs/heads/ci/'))
+    uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
+    with:
+      environment: dev
+      env: dev
+      git_sha: ${{ github.sha }}
+      service_name: ant-cli-preview
+      dockerfile: ./packages/ant-cli/Dockerfile
+      target: preview
+      build_args: |
+        GO_VERSION=${{ vars.PREVIEW_GO_VERSION }}
+        PYTHON_VERSION=${{ vars.PREVIEW_PYTHON_VERSION }}
+        RUST_VERSION=${{ vars.PREVIEW_RUST_VERSION }}
+        JAVA_VERSION=${{ vars.PREVIEW_JAVA_VERSION }}
     secrets: inherit
 
   # ===========================================
@@ -193,6 +234,27 @@ jobs:
     secrets: inherit
 
   # ===========================================
+  # Stage branch - ant-cli-preview deployment
+  # ===========================================
+  auto-ant-cli-preview-stage-deploy:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.ant-cli-changed == 'true' && needs.detect-changes.outputs.root-package-changed != 'true' && startsWith(github.ref, 'refs/heads/stage')
+    uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
+    with:
+      environment: stage
+      env: stage
+      git_sha: ${{ github.sha }}
+      service_name: ant-cli-preview
+      dockerfile: ./packages/ant-cli/Dockerfile
+      target: preview
+      build_args: |
+        GO_VERSION=${{ vars.PREVIEW_GO_VERSION }}
+        PYTHON_VERSION=${{ vars.PREVIEW_PYTHON_VERSION }}
+        RUST_VERSION=${{ vars.PREVIEW_RUST_VERSION }}
+        JAVA_VERSION=${{ vars.PREVIEW_JAVA_VERSION }}
+    secrets: inherit
+
+  # ===========================================
   # Stage branch - Deploy all when root package.json changes
   # ===========================================
   auto-all-ant-ui-stage-deploy:
@@ -217,6 +279,24 @@ jobs:
       git_sha: ${{ github.sha }}
       service_name: ant-cli
       dockerfile: ./packages/ant-cli/Dockerfile
+    secrets: inherit
+
+  auto-all-ant-cli-preview-stage-deploy:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.root-package-changed == 'true' && startsWith(github.ref, 'refs/heads/stage')
+    uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
+    with:
+      environment: stage
+      env: stage
+      git_sha: ${{ github.sha }}
+      service_name: ant-cli-preview
+      dockerfile: ./packages/ant-cli/Dockerfile
+      target: preview
+      build_args: |
+        GO_VERSION=${{ vars.PREVIEW_GO_VERSION }}
+        PYTHON_VERSION=${{ vars.PREVIEW_PYTHON_VERSION }}
+        RUST_VERSION=${{ vars.PREVIEW_RUST_VERSION }}
+        JAVA_VERSION=${{ vars.PREVIEW_JAVA_VERSION }}
     secrets: inherit
 
   # ===========================================
@@ -252,6 +332,28 @@ jobs:
     secrets: inherit
 
   # ===========================================
+  # Manual deployment workflow - ant-cli-preview (dev, stage only)
+  # ===========================================
+  manual-ant-cli-preview-deploy:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.service == 'ant-cli-preview' && github.event.inputs.environment != 'prod'
+    uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
+    with:
+      environment: ${{ github.event.inputs.environment }}
+      env: ${{ github.event.inputs.environment }}
+      git_sha: ${{ github.sha }}
+      service_name: ant-cli-preview
+      ticket_id: ${{ github.event.inputs.ticket_id || '' }}
+      git_ref: ${{ github.event.inputs.git_ref || '' }}
+      dockerfile: ./packages/ant-cli/Dockerfile
+      target: preview
+      build_args: |
+        GO_VERSION=${{ vars.PREVIEW_GO_VERSION }}
+        PYTHON_VERSION=${{ vars.PREVIEW_PYTHON_VERSION }}
+        RUST_VERSION=${{ vars.PREVIEW_RUST_VERSION }}
+        JAVA_VERSION=${{ vars.PREVIEW_JAVA_VERSION }}
+    secrets: inherit
+
+  # ===========================================
   # Release (prod) deployment via repository_dispatch or workflow_dispatch
   # ===========================================
   release-deploy-ant-ui:
@@ -282,4 +384,25 @@ jobs:
       ticket_id: ${{ github.event.inputs.ticket_id || '' }}
       git_ref: ${{ github.event.inputs.git_ref || '' }}
       dockerfile: ./packages/ant-cli/Dockerfile
+    secrets: inherit
+
+  release-deploy-ant-cli-preview:
+    if: >
+      (github.event_name == 'repository_dispatch' && github.event.inputs.environment == 'prod') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'prod' && github.event.inputs.service == 'ant-cli-preview')
+    uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
+    with:
+      environment: prod
+      env: prod
+      git_sha: ${{ github.sha }}
+      service_name: ant-cli-preview
+      ticket_id: ${{ github.event.inputs.ticket_id || '' }}
+      git_ref: ${{ github.event.inputs.git_ref || '' }}
+      dockerfile: ./packages/ant-cli/Dockerfile
+      target: preview
+      build_args: |
+        GO_VERSION=${{ vars.PREVIEW_GO_VERSION }}
+        PYTHON_VERSION=${{ vars.PREVIEW_PYTHON_VERSION }}
+        RUST_VERSION=${{ vars.PREVIEW_RUST_VERSION }}
+        JAVA_VERSION=${{ vars.PREVIEW_JAVA_VERSION }}
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ on:
         options:
           - ant-ui
           - ant-cli
-          - ant-cli-preview
+          - ant-preview
       git_ref:
         description: 'Git reference (commit SHA, branch, or tag) to deploy'
         required: false
@@ -137,10 +137,10 @@ jobs:
     secrets: inherit
 
   # ===========================================
-  # Dev environment - ant-cli-preview deployment (main, dev, ci/* branches)
-  # ant-cli-preview 이미지: preview 워커 전용 (멀티 언어 런타임 포함)
+  # Dev environment - ant-preview deployment (main, dev, ci/* branches)
+  # ant-preview 이미지: preview 워커 전용 (멀티 언어 런타임 포함)
   # ===========================================
-  auto-ant-cli-preview-dev-deploy:
+  auto-ant-preview-dev-deploy:
     needs: detect-changes
     if: needs.detect-changes.outputs.ant-cli-changed == 'true' && needs.detect-changes.outputs.root-package-changed != 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/dev') || github.ref == 'refs/heads/cloud-scalability' || startsWith(github.ref, 'refs/heads/ci/'))
     uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
@@ -148,7 +148,7 @@ jobs:
       environment: dev
       env: dev
       git_sha: ${{ github.sha }}
-      service_name: ant-cli-preview
+      service_name: ant-preview
       dockerfile: ./packages/ant-cli/Dockerfile
       target: preview
       build_args: |
@@ -185,7 +185,7 @@ jobs:
       dockerfile: ./packages/ant-cli/Dockerfile
     secrets: inherit
 
-  auto-all-ant-cli-preview-dev-deploy:
+  auto-all-ant-preview-dev-deploy:
     needs: detect-changes
     if: needs.detect-changes.outputs.root-package-changed == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/dev') || github.ref == 'refs/heads/cloud-scalability' || startsWith(github.ref, 'refs/heads/ci/'))
     uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
@@ -193,7 +193,7 @@ jobs:
       environment: dev
       env: dev
       git_sha: ${{ github.sha }}
-      service_name: ant-cli-preview
+      service_name: ant-preview
       dockerfile: ./packages/ant-cli/Dockerfile
       target: preview
       build_args: |
@@ -234,9 +234,9 @@ jobs:
     secrets: inherit
 
   # ===========================================
-  # Stage branch - ant-cli-preview deployment
+  # Stage branch - ant-preview deployment
   # ===========================================
-  auto-ant-cli-preview-stage-deploy:
+  auto-ant-preview-stage-deploy:
     needs: detect-changes
     if: needs.detect-changes.outputs.ant-cli-changed == 'true' && needs.detect-changes.outputs.root-package-changed != 'true' && startsWith(github.ref, 'refs/heads/stage')
     uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
@@ -244,7 +244,7 @@ jobs:
       environment: stage
       env: stage
       git_sha: ${{ github.sha }}
-      service_name: ant-cli-preview
+      service_name: ant-preview
       dockerfile: ./packages/ant-cli/Dockerfile
       target: preview
       build_args: |
@@ -281,7 +281,7 @@ jobs:
       dockerfile: ./packages/ant-cli/Dockerfile
     secrets: inherit
 
-  auto-all-ant-cli-preview-stage-deploy:
+  auto-all-ant-preview-stage-deploy:
     needs: detect-changes
     if: needs.detect-changes.outputs.root-package-changed == 'true' && startsWith(github.ref, 'refs/heads/stage')
     uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
@@ -289,7 +289,7 @@ jobs:
       environment: stage
       env: stage
       git_sha: ${{ github.sha }}
-      service_name: ant-cli-preview
+      service_name: ant-preview
       dockerfile: ./packages/ant-cli/Dockerfile
       target: preview
       build_args: |
@@ -332,16 +332,16 @@ jobs:
     secrets: inherit
 
   # ===========================================
-  # Manual deployment workflow - ant-cli-preview (dev, stage only)
+  # Manual deployment workflow - ant-preview (dev, stage only)
   # ===========================================
-  manual-ant-cli-preview-deploy:
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.service == 'ant-cli-preview' && github.event.inputs.environment != 'prod'
+  manual-ant-preview-deploy:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.service == 'ant-preview' && github.event.inputs.environment != 'prod'
     uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
     with:
       environment: ${{ github.event.inputs.environment }}
       env: ${{ github.event.inputs.environment }}
       git_sha: ${{ github.sha }}
-      service_name: ant-cli-preview
+      service_name: ant-preview
       ticket_id: ${{ github.event.inputs.ticket_id || '' }}
       git_ref: ${{ github.event.inputs.git_ref || '' }}
       dockerfile: ./packages/ant-cli/Dockerfile
@@ -386,16 +386,16 @@ jobs:
       dockerfile: ./packages/ant-cli/Dockerfile
     secrets: inherit
 
-  release-deploy-ant-cli-preview:
+  release-deploy-ant-preview:
     if: >
       (github.event_name == 'repository_dispatch' && github.event.inputs.environment == 'prod') ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'prod' && github.event.inputs.service == 'ant-cli-preview')
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'prod' && github.event.inputs.service == 'ant-preview')
     uses: to-nexus/cross-hub-workflows/.github/workflows/ant.yml@master
     with:
       environment: prod
       env: prod
       git_sha: ${{ github.sha }}
-      service_name: ant-cli-preview
+      service_name: ant-preview
       ticket_id: ${{ github.event.inputs.ticket_id || '' }}
       git_ref: ${{ github.event.inputs.git_ref || '' }}
       dockerfile: ./packages/ant-cli/Dockerfile

--- a/packages/ant-cli/Dockerfile
+++ b/packages/ant-cli/Dockerfile
@@ -262,3 +262,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
 
 # Start server using tsx (avoids ESM module resolution issues)
 CMD ["tsx", "src/composition/server.ts"]
+

--- a/packages/ant-cli/Dockerfile
+++ b/packages/ant-cli/Dockerfile
@@ -262,4 +262,3 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
 
 # Start server using tsx (avoids ESM module resolution issues)
 CMD ["tsx", "src/composition/server.ts"]
-

--- a/packages/ant-cli/Dockerfile
+++ b/packages/ant-cli/Dockerfile
@@ -1,7 +1,21 @@
 # ============================================
-# ANT CLI - Production Dockerfile
+# ANT CLI - Dockerfile
 # ============================================
-# Multi-stage build for optimized image size
+# Multi-stage build:
+#   builder    — TypeScript compile (node:20)
+#   preview    — Multi-language runtime for preview worker (node:20-alpine)
+#   production — Lean runtime for api/job workers (node:20-alpine)  ← default
+#
+# Build targets:
+#   docker build .                        → production (api/job)
+#   docker build --target preview .       → preview worker
+#
+# Language toolchain ARGs (preview only):
+#   GO_VERSION      base Go toolchain; per-project via go.mod toolchain + GOTOOLCHAIN=auto
+#   PYTHON_VERSION  base Python via uv; per-project via .python-version / pyproject.toml
+#   RUST_VERSION    base Rust via rustup; per-project via rust-toolchain.toml
+#   JAVA_VERSION    base Java via mise; per-project via .mise.toml / .tool-versions
+#
 # Environment variables are injected via Vault Injector at runtime
 # ============================================
 
@@ -41,7 +55,132 @@ COPY packages/ant-cli ./packages/ant-cli
 RUN pnpm build:cli
 
 # ============================================
-# Stage 2: Production
+# Stage 2: Preview (multi-language runtime for preview worker)
+# ============================================
+# Starts fresh from node:20-alpine (does NOT extend production) so that
+# language runtimes can be added incrementally without polluting api/job image.
+FROM node:20-alpine AS preview
+
+# --- Language version ARGs (empty string = skip install) ---
+ARG GO_VERSION="1.23.6"
+ARG PYTHON_VERSION=""
+ARG RUST_VERSION=""
+ARG JAVA_VERSION=""
+
+# Base system deps (curl/bash needed by rustup/uv/mise installers)
+RUN apk add --no-cache \
+    git \
+    ca-certificates \
+    wget \
+    curl \
+    bash \
+    gcc \
+    musl-dev \
+    build-base
+
+# -------- Go (official binary + GOTOOLCHAIN=auto) --------
+# Installs base toolchain; per-project go.mod/go.work `toolchain` directive
+# controls the actual version used at runtime via GOTOOLCHAIN=auto.
+RUN if [ -n "${GO_VERSION}" ]; then \
+      wget -qO /tmp/go.tar.gz \
+        "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" && \
+      tar -C /usr/local -xzf /tmp/go.tar.gz && \
+      rm /tmp/go.tar.gz; \
+    fi
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="/home/ant/go"
+ENV GOTOOLCHAIN=auto
+
+# -------- Python (uv — .python-version / pyproject.toml auto-switch) --------
+# `uv run` and `uv sync` automatically read .python-version for per-project version.
+RUN if [ -n "${PYTHON_VERSION}" ]; then \
+      curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh && \
+      uv python install "${PYTHON_VERSION}"; \
+    fi
+
+# -------- Rust (rustup — rust-toolchain.toml auto-switch) --------
+# RUSTUP_AUTO_INSTALL=1 causes rustup to auto-download the toolchain
+# specified in rust-toolchain.toml when first invoked in a project.
+ENV RUSTUP_HOME="/usr/local/rustup"
+ENV CARGO_HOME="/usr/local/cargo"
+RUN if [ -n "${RUST_VERSION}" ]; then \
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --default-toolchain "${RUST_VERSION}" --no-modify-path; \
+    fi
+ENV PATH="${PATH}:/usr/local/cargo/bin"
+ENV RUSTUP_AUTO_INSTALL=1
+
+# -------- Java (mise — .mise.toml / .tool-versions auto-switch) --------
+# MISE_AUTO_INSTALL=true causes mise shims to auto-install the version
+# specified in .mise.toml or .tool-versions when first invoked.
+RUN if [ -n "${JAVA_VERSION}" ]; then \
+      curl https://mise.run | sh && \
+      /root/.local/bin/mise use --global "java@${JAVA_VERSION}"; \
+    fi
+ENV PATH="${PATH}:/root/.local/share/mise/shims"
+ENV MISE_AUTO_INSTALL=true
+
+# -------- Node.js tooling --------
+RUN npm install -g pnpm tsx
+
+# Create non-root user
+RUN addgroup -S ant && adduser -S -G ant ant
+
+WORKDIR /app
+
+# Copy workspace configuration
+COPY pnpm-workspace.yaml ./
+COPY package.json ./
+COPY pnpm-lock.yaml ./
+
+# Copy ant-cli package.json
+COPY packages/ant-cli/package.json ./packages/ant-cli/
+
+# Install all dependencies
+RUN pnpm install --frozen-lockfile --ignore-scripts
+
+# Copy built artifacts from builder stage
+COPY --from=builder /app/packages/ant-cli/dist ./packages/ant-cli/dist
+
+# Copy runtime assets (templates, profiles)
+COPY --from=builder /app/packages/ant-cli/dist/core/prompt/templates ./packages/ant-cli/dist/core/prompt/templates
+COPY --from=builder /app/packages/ant-cli/dist/periphery/profiles ./packages/ant-cli/dist/periphery/profiles
+
+# Copy source code for tsx execution
+COPY --from=builder /app/packages/ant-cli/src ./packages/ant-cli/src
+COPY --from=builder /app/packages/ant-cli/tsconfig.json ./packages/ant-cli/tsconfig.json
+
+# Copy monorepo docs
+COPY docs ./docs
+
+# Create workspace directory and fix ownership
+RUN mkdir -p /cross/workspaces && chown -R ant:ant /cross/workspaces
+RUN mkdir -p /home/ant/go && chown -R ant:ant /home/ant/go
+RUN if [ -d /usr/local/rustup ]; then chown -R ant:ant /usr/local/rustup /usr/local/cargo; fi
+RUN chown -R ant:ant /app
+
+USER ant
+
+WORKDIR /app/packages/ant-cli
+
+ENV NODE_ENV=production
+ENV ANT_SERVER_MODE=cloud
+ENV ANT_CLI_PORT=4100
+ENV ANT_WORKSPACE_BASE_PATH=/data/workspaces
+ENV GOOGLE_REDIRECT_URI=""
+ENV FRONTEND_URL=""
+ENV SKIP_AUTH_FOR_LOCALHOST="false"
+ENV NODE_OPTIONS="--max-old-space-size=8192"
+
+EXPOSE 4100
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+    CMD node -e "require('http').get('http://localhost:4100/api/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))"
+
+CMD ["tsx", "src/composition/server.ts"]
+
+# ============================================
+# Stage 3: Production (api/job — lean, no language runtimes)
 # ============================================
 FROM node:20-alpine AS production
 

--- a/packages/ant-cli/Dockerfile
+++ b/packages/ant-cli/Dockerfile
@@ -76,7 +76,9 @@ RUN apk add --no-cache \
     bash \
     gcc \
     musl-dev \
-    build-base
+    build-base \
+    docker-cli \
+    docker-cli-compose
 
 # -------- Go (official binary + GOTOOLCHAIN=auto) --------
 # Installs base toolchain; per-project go.mod/go.work `toolchain` directive
@@ -184,10 +186,25 @@ CMD ["tsx", "src/composition/server.ts"]
 # ============================================
 FROM node:20-alpine AS production
 
+# Language version ARG (empty = skip install)
+ARG GO_VERSION="1.23.6"
+
 # Install runtime dependencies
 RUN apk add --no-cache \
     git \
-    ca-certificates
+    ca-certificates \
+    wget
+
+# Go toolchain (official binary + GOTOOLCHAIN=auto for per-project version switching)
+RUN if [ -n "${GO_VERSION}" ]; then \
+      wget -qO /tmp/go.tar.gz \
+        "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" && \
+      tar -C /usr/local -xzf /tmp/go.tar.gz && \
+      rm /tmp/go.tar.gz; \
+    fi
+ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GOPATH="/home/ant/go"
+ENV GOTOOLCHAIN=auto
 
 # Install pnpm and tsx for production
 RUN npm install -g pnpm tsx
@@ -226,6 +243,7 @@ COPY docs ./docs
 RUN mkdir -p /cross/workspaces && chown -R ant:ant /cross/workspaces
 
 # Set ownership
+RUN mkdir -p /home/ant/go && chown -R ant:ant /home/ant/go
 RUN chown -R ant:ant /app
 
 # Switch to non-root user


### PR DESCRIPTION
ant-preview 빌드 target 분리. 

* 향후 Rust/Java/Python 관련 빌드 미리 삽입 - Git Repo Variable로 값이 없으면 동작하지 않음. 
* 현재 단계에서는 Go 이외에 언어 지원 안함. 
* 빌드/배포는 이전과 동일. 


언어 | ARG | 매니저 | 자동 전환
-- | -- | -- | --
Go | GO_VERSION="1.23.6" | 공식 바이너리 | GOTOOLCHAIN=auto
Python | PYTHON_VERSION="" | uv | .python-version 자동 인식
Rust | RUST_VERSION="" | rustup | RUSTUP_AUTO_INSTALL=1
Java | JAVA_VERSION="" | mise | MISE_AUTO_INSTALL=true

