### PR TITLE
Ci/modify go lib

### DIFF
--- a/packages/ant-cli/Dockerfile
+++ b/packages/ant-cli/Dockerfile
@@ -284,4 +284,3 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
 
 # Start server using tsx (avoids ESM module resolution issues)
 CMD ["tsx", "src/composition/server.ts"]
-

--- a/packages/ant-cli/Dockerfile
+++ b/packages/ant-cli/Dockerfile
@@ -68,6 +68,7 @@ ARG RUST_VERSION=""
 ARG JAVA_VERSION=""
 
 # Base system deps (curl/bash needed by rustup/uv/mise installers)
+# libc6-compat: required to run official Go binaries (glibc-linked) on Alpine (musl)
 RUN apk add --no-cache \
     git \
     ca-certificates \
@@ -77,6 +78,7 @@ RUN apk add --no-cache \
     gcc \
     musl-dev \
     build-base \
+    libc6-compat \
     docker-cli \
     docker-cli-compose
 
@@ -190,10 +192,12 @@ FROM node:20-alpine AS production
 ARG GO_VERSION="1.23.6"
 
 # Install runtime dependencies
+# libc6-compat: required to run official Go binaries (glibc-linked) on Alpine (musl)
 RUN apk add --no-cache \
     git \
     ca-certificates \
-    wget
+    wget \
+    libc6-compat
 
 # Go toolchain (official binary + GOTOOLCHAIN=auto for per-project version switching)
 RUN if [ -n "${GO_VERSION}" ]; then \


### PR DESCRIPTION
공식 Go 바이너리 (dl.google.com/go/go1.23.6.linux-amd64.tar.gz)
  → glibc 동적 링커 필요 (/lib64/ld-linux-x86-64.so.2)

Alpine (node:20-alpine)
  → musl libc 사용 (/lib/ld-musl-x86_64.so.1)
  → glibc 링커 없음 

libc6-compat 설치
  → glibc 호환 심볼릭 링크 제공 → Go 바이너리 정상 실행 ✅