### PR TITLE
fix(cloud): 멀티팟 환경 프로젝트/피처 삭제 버그 수정

### DIFF
--- a/packages/ant-cli/src/periphery/adapters/http/express/services/ServiceInitializer.ts
+++ b/packages/ant-cli/src/periphery/adapters/http/express/services/ServiceInitializer.ts
@@ -15,7 +15,7 @@ import { AuthService } from '../../../../../infrastructure/auth/AuthService';
 import { GoogleOIDCService } from '../../../../../infrastructure/auth/GoogleOIDCService';
 import { createJwtServiceFromEnv } from '../../../../../infrastructure/auth/JwtService';
 import { PortManager } from '../../../../../infrastructure/networking/PortManager';
-import { IDEService } from '../../../ide/IDEService';
+import { IDEOrchestratorPort } from '../../../../../core/ports/ideOrchestrator';
 import { logger } from '../../../../../utils/logger';
 import { ServerConfig, ServerDependencies } from '../types';
 import { getInfrastructureFactory } from '../../../../../infrastructure/adapters/InfrastructureFactory';
@@ -43,8 +43,12 @@ export function initializeServices(
   const portRegistry: PortRegistryPort = factory.getStateStore() as unknown as PortRegistryPort;
   logger.info('Using RedisStateStore as PortRegistry', { component: 'ServiceInitializer' });
   
-  const ideService = new IDEService(portManager, portRegistry);
-  ideService.startIdleChecker();
+  // Use IDEOrchestratorPort: K8s mode → KubernetesIDEOrchestrator, local → LocalIDEOrchestrator (Docker)
+  // This avoids Docker socket access in K8s pods where /var/run/docker.sock doesn't exist
+  factory.setDependencies(portManager, portRegistry);
+  const ideOrchestrator: IDEOrchestratorPort = factory.getIDEOrchestrator();
+  ideOrchestrator.startIdleCheck();
+  logger.info(`IDE Orchestrator: ${ideOrchestrator.constructor.name}`, { component: 'ServiceInitializer' });
   
   // Initialize AuthService + JWT for Cloud mode
   let authService: AuthService | undefined;
@@ -97,7 +101,7 @@ export function initializeServices(
     workspaceResolver, 
     githubAuthService, 
     chatService, 
-    ideService
+    ideOrchestrator
   );
   const kanbanService = new KanbanService(config.workspacesPath, workspaceResolver, stateStore);
   
@@ -134,7 +138,7 @@ export function initializeServices(
     jwtService,
     portManager,
     portRegistry,
-    ideService,
+    ideService: ideOrchestrator,
     kanbanService,
     sessionService,
     gitWatcherService,

--- a/packages/ant-cli/src/periphery/adapters/http/services/ProjectService/FeatureCrudService.ts
+++ b/packages/ant-cli/src/periphery/adapters/http/services/ProjectService/FeatureCrudService.ts
@@ -25,6 +25,29 @@ export class FeatureCrudService {
   setWorktreeService(service: WorktreeService) {
     this.worktreeService = service;
   }
+
+  /**
+   * NFS-safe file read with retry for ESTALE (errno -116) stale file handles.
+   * In multi-pod K8s environments with EFS/NFS, another pod may modify files
+   * causing the local kernel to hold a stale inode reference.
+   * A short delay + retry forces the NFS client to re-lookup the inode.
+   */
+  private async readFileWithRetry(filePath: string, retries = 2): Promise<string> {
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      try {
+        return await fs.promises.readFile(filePath, 'utf-8');
+      } catch (err: any) {
+        const isStale = err.errno === -116 || err.code === 'ESTALE' 
+          || (err.message && err.message.includes('system error -116'));
+        if (isStale && attempt < retries) {
+          await new Promise(r => setTimeout(r, 100 * (attempt + 1)));
+          continue;
+        }
+        throw err;
+      }
+    }
+    throw new Error(`Failed to read file after ${retries} retries: ${filePath}`);
+  }
   
   /**
    * Get session data for a feature
@@ -38,17 +61,15 @@ export class FeatureCrudService {
     const featurePath = this.workspaceResolver.getFeaturePath(userContext, projectId, featureName);
     const sessionPath = getSessionFilePathByJob(featurePath, job);
     
-    // Check if session file exists
-    const exists = await fs.promises.access(sessionPath)
-      .then(() => true)
-      .catch(() => false);
-    
-    if (!exists) {
-      throw new Error('Session file not found');
+    try {
+      const sessionData = await this.readFileWithRetry(sessionPath);
+      return JSON.parse(sessionData);
+    } catch (err: any) {
+      if (err.code === 'ENOENT') {
+        throw new Error('Session file not found');
+      }
+      throw err;
     }
-    
-    const sessionData = await fs.promises.readFile(sessionPath, 'utf-8');
-    return JSON.parse(sessionData);
   }
   
   /**
@@ -112,8 +133,12 @@ export class FeatureCrudService {
         .filter(item => !item.startsWith('.'))
         .map(async (item) => {
           const itemPath = path.join(featuresPath, item);
-          const stat = await fs.promises.stat(itemPath);
-          return stat.isDirectory() ? item : null;
+          try {
+            const stat = await fs.promises.stat(itemPath);
+            return stat.isDirectory() ? item : null;
+          } catch {
+            return null;
+          }
         })
     );
     

--- a/packages/ant-cli/src/periphery/adapters/http/services/ProjectService/ProjectCrudService.ts
+++ b/packages/ant-cli/src/periphery/adapters/http/services/ProjectService/ProjectCrudService.ts
@@ -285,8 +285,10 @@ export class ProjectCrudService {
     } catch (error) {
       // If config doesn't exist, return minimal default config
       console.warn('[ProjectCrudService] Config not found, returning defaults');
+      const isCloudMode = userContext.userId !== 'local' && userContext.organizationId !== 'local';
       return {
         repositoryName: this.sanitizeProjectName(id),
+        repoType: isCloudMode ? 'cloud' : 'local',
         branchBase: 'main',
         llmModels: {
           design: {

--- a/packages/ant-cli/src/periphery/adapters/http/services/ProjectService/index.ts
+++ b/packages/ant-cli/src/periphery/adapters/http/services/ProjectService/index.ts
@@ -2,7 +2,7 @@ import { WorkspaceResolver } from '../../../../../infrastructure/workspace/Works
 import { UserContext } from '../../../../../core/types/user';
 import { GitHubAuthService } from '../../../auth/GitHubAuthService';
 import { ChatService } from '../ChatService';
-import type { IDEService } from '../../../ide/IDEService';
+import type { IDEOrchestratorPort } from '../../../../../core/ports/ideOrchestrator';
 
 // Import sub-services
 import { ProjectCrudService } from './ProjectCrudService';
@@ -27,7 +27,7 @@ export class ProjectService {
   private readonly workspaceResolver: WorkspaceResolver;
   private readonly githubAuthService?: GitHubAuthService;
   private readonly chatService?: ChatService;
-  private readonly ideService?: IDEService;
+  private readonly ideOrchestrator?: IDEOrchestratorPort;
   
   // Sub-services
   private readonly projectCrud: ProjectCrudService;
@@ -39,12 +39,12 @@ export class ProjectService {
     workspaceResolver: WorkspaceResolver,
     githubAuthService?: GitHubAuthService,
     chatService?: ChatService,
-    ideService?: IDEService
+    ideOrchestrator?: IDEOrchestratorPort
   ) {
     this.workspaceResolver = workspaceResolver;
     this.githubAuthService = githubAuthService;
     this.chatService = chatService;
-    this.ideService = ideService;
+    this.ideOrchestrator = ideOrchestrator;
     
     // Initialize sub-services
     this.projectCrud = new ProjectCrudService(workspaceResolver);
@@ -74,9 +74,13 @@ export class ProjectService {
   }
   
   async deleteProject(id: string, userContext: UserContext): Promise<void> {
-    // ✅ Cleanup IDE resources first (stop+remove containers, delete IDE home) to avoid dangling resources
-    if (this.ideService) {
-      await this.ideService.cleanupProject(userContext, id, { deleteHome: true });
+    // Cleanup IDE resources first (stop+remove pods/containers, delete IDE home) to avoid dangling resources
+    if (this.ideOrchestrator) {
+      try {
+        await this.ideOrchestrator.cleanupProject(userContext, id, { deleteHome: true });
+      } catch (e: any) {
+        console.warn(`[ProjectService] IDE cleanup for project ${id} failed (non-critical): ${e.message}`);
+      }
     }
     return this.projectCrud.deleteProject(id, userContext);
   }
@@ -102,6 +106,13 @@ export class ProjectService {
   }
   
   async deleteFeature(projectId: string, featureName: string, userContext: UserContext): Promise<void> {
+    // Stop IDE pod/container for this feature before deleting the feature directory
+    if (this.ideOrchestrator) {
+      const tenantId = `${userContext.organizationId}:${userContext.userId}`;
+      await this.ideOrchestrator.stop(tenantId, projectId, featureName).catch((e: any) => {
+        console.warn(`[ProjectService] IDE stop for feature ${featureName} failed (non-critical): ${e.message}`);
+      });
+    }
     return this.featureCrud.deleteFeature(projectId, featureName, userContext);
   }
   

--- a/packages/ant-ui/src/infrastructure/http/api/config.ts
+++ b/packages/ant-ui/src/infrastructure/http/api/config.ts
@@ -46,12 +46,15 @@ function sanitizeRepositoryName(workspaceId: string): string {
 }
 
 /** Create project config with defaults */
-export async function createProjectConfig(projectId: string): Promise<ProjectConfig> {
+export async function createProjectConfig(
+  projectId: string,
+  mode: 'local' | 'cloud' = 'local',
+): Promise<ProjectConfig> {
   const sanitizedName = sanitizeRepositoryName(projectId);
   const defaultConfig: ProjectConfig = {
     repositoryName: sanitizedName,
-    repoType: 'local',
-    localPath: `~/dev/${sanitizedName}`,
+    repoType: mode === 'cloud' ? 'cloud' : 'local',
+    ...(mode !== 'cloud' ? { localPath: `~/dev/${sanitizedName}` } : {}),
     branchBase: 'main',
   };
   await apiPut(

--- a/packages/ant-ui/src/presentation/components/ProjectSection.tsx
+++ b/packages/ant-ui/src/presentation/components/ProjectSection.tsx
@@ -33,7 +33,8 @@ export function ProjectSection() {
     gitStatus,  // ✅ Use unified Git status from store
     fetchGitStatus,  // ✅ Fetch Git status action
     setGitStatusPhase,  // ✅ Git status phase setter
-    gitStatusRefreshTrigger  // ✅ Git status refresh trigger
+    gitStatusRefreshTrigger,  // ✅ Git status refresh trigger
+    backendMode
   } = useStore();
   const [configExists, setConfigExists] = useState<boolean | null>(null);
   const [config, setConfig] = useState<ProjectConfig | null>(null);
@@ -109,7 +110,7 @@ export function ProjectSection() {
     // If config doesn't exist, create it first
     if (configExists === false) {
       try {
-        await createProjectConfig(selectedProject);
+        await createProjectConfig(selectedProject, backendMode);
         setConfigExists(true);
         // Wait a moment for the backend to write the file
         await new Promise(resolve => setTimeout(resolve, 100));
@@ -405,8 +406,8 @@ export function ProjectSection() {
             </div>
           )}
           
-          {/* ✅ Only show localPath warning for local/github repo types, not cloud */}
-          {configExists && !config?.localPath && config?.repoType !== 'cloud' && (
+          {/* Only show localPath warning in local backend mode, for local/github repo types */}
+          {backendMode !== 'cloud' && configExists && !config?.localPath && config?.repoType !== 'cloud' && (
             <div className="mt-2 p-2 bg-orange-50 dark:bg-orange-950/30 border border-orange-200 dark:border-orange-800 rounded-md">
               <div className="flex items-start gap-1.5">
                 <span className="text-orange-600 dark:text-orange-400 text-xs flex-shrink-0">⚠️</span>


### PR DESCRIPTION
- K8s 환경에서 Docker socket ENOENT 제거: IDEService(Docker 전용) 대신 IDEOrchestratorPort(K8s/Docker 자동 선택)를 ProjectService에 주입
- 프로젝트/피처 삭제 시 IDE Pod/Container cleanup 추가 (best-effort)
- EFS/NFS ESTALE(errno -116) 에러 처리: readFileWithRetry로 재시도, listFeatures stat 실패 시 해당 항목 skip
- getProjectConfig fallback에 repoType 포함하여 UI 경고 오탐 방지
- 클라우드 모드에서 "로컬 경로 미설정" 경고 비표시 (backendMode 체크)
- createProjectConfig에 mode 파라미터 추가하여 cloud 시 repoType:'cloud' 설정

Made-with: Cursor