### PR TITLE
fix: upload ant-ui assets to S3 with app/ prefix to match CloudFront …

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -159,7 +159,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION || 'ap-northeast-2' }}
       - name: Deploy to S3 + invalidate CloudFront
         run: |
-          aws s3 sync packages/ant-ui/dist/ s3://${{ vars.ANT_UI_S3_BUCKET }}/ --delete
+          aws s3 sync packages/ant-ui/dist/ s3://${{ vars.ANT_UI_S3_BUCKET }}/app/ --delete
           aws cloudfront create-invalidation --distribution-id ${{ vars.ANT_UI_CF_DISTRIBUTION_ID }} --paths "/app/*"
 
   # ===========================================
@@ -266,7 +266,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION || 'ap-northeast-2' }}
       - name: Deploy to S3 + invalidate CloudFront
         run: |
-          aws s3 sync packages/ant-ui/dist/ s3://${{ vars.ANT_UI_S3_BUCKET }}/ --delete
+          aws s3 sync packages/ant-ui/dist/ s3://${{ vars.ANT_UI_S3_BUCKET }}/app/ --delete
           aws cloudfront create-invalidation --distribution-id ${{ vars.ANT_UI_CF_DISTRIBUTION_ID }} --paths "/app/*"
 
   auto-all-ant-cli-dev-deploy:
@@ -331,7 +331,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION || 'ap-northeast-2' }}
       - name: Deploy to S3 + invalidate CloudFront
         run: |
-          aws s3 sync packages/ant-ui/dist/ s3://${{ vars.ANT_UI_S3_BUCKET }}/ --delete
+          aws s3 sync packages/ant-ui/dist/ s3://${{ vars.ANT_UI_S3_BUCKET }}/app/ --delete
           aws cloudfront create-invalidation --distribution-id ${{ vars.ANT_UI_CF_DISTRIBUTION_ID }} --paths "/app/*"
 
   # ===========================================
@@ -436,7 +436,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION || 'ap-northeast-2' }}
       - name: Deploy to S3 + invalidate CloudFront
         run: |
-          aws s3 sync packages/ant-ui/dist/ s3://${{ vars.ANT_UI_S3_BUCKET }}/ --delete
+          aws s3 sync packages/ant-ui/dist/ s3://${{ vars.ANT_UI_S3_BUCKET }}/app/ --delete
           aws cloudfront create-invalidation --distribution-id ${{ vars.ANT_UI_CF_DISTRIBUTION_ID }} --paths "/app/*"
 
   auto-all-ant-cli-stage-deploy:
@@ -502,7 +502,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION || 'ap-northeast-2' }}
       - name: Deploy to S3 + invalidate CloudFront
         run: |
-          aws s3 sync packages/ant-ui/dist/ s3://${{ vars.ANT_UI_S3_BUCKET }}/ --delete
+          aws s3 sync packages/ant-ui/dist/ s3://${{ vars.ANT_UI_S3_BUCKET }}/app/ --delete
           aws cloudfront create-invalidation --distribution-id ${{ vars.ANT_UI_CF_DISTRIBUTION_ID }} --paths "/app/*"
 
   # ===========================================
@@ -613,7 +613,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION || 'ap-northeast-2' }}
       - name: Deploy to S3 + invalidate CloudFront
         run: |
-          aws s3 sync packages/ant-ui/dist/ s3://${{ vars.ANT_UI_S3_BUCKET }}/ --delete
+          aws s3 sync packages/ant-ui/dist/ s3://${{ vars.ANT_UI_S3_BUCKET }}/app/ --delete
           aws cloudfront create-invalidation --distribution-id ${{ vars.ANT_UI_CF_DISTRIBUTION_ID }} --paths "/app/*"
 
   release-deploy-ant-site:


### PR DESCRIPTION
## 문제

`/app/*` 경로 새로고침 시 site 페이지와 app 페이지가 번갈아 표시되는 현상.

## 원인

ant-ui 빌드 결과물이 S3 버킷 루트(`index.html`, `assets/`, ...)에 업로드되고 있었음.

CloudFront `/app/*` behavior → spa-fallback Function이 `/app/index.html`로 리라이트 →

S3에 `app/index.html` 키가 없어 403 → Custom Error Response가 site-origin 콘텐츠를 반환.

## 수정

`s3 sync` destination을 `s3://{bucket}/` → `s3://{bucket}/app/`으로 변경.

S3 키가 `app/index.html`, `app/assets/...` 형태가 되어 spa-fallback이 정상 동작.

## 변경 범위

deploy.yml 내 ant-ui S3 sync 6곳 (dev auto/all, stage auto/all, manual, prod release)

## 배포 후 확인

- [x] `https://ant.crosstoken.io/app/` 반복 새로고침 시 항상 app 페이지 표시

- [x] S3 버킷 루트의 잔여 파일 수동 정리 (`index.html`, `assets/` 등)