### PR TITLE
fix(execute): stop marker-mimicry loop with truthful file-write feedback

### DIFF
--- a/packages/ant-cli/src/agents/architect/graph/code/nodes/execute/index.ts
+++ b/packages/ant-cli/src/agents/architect/graph/code/nodes/execute/index.ts
@@ -670,7 +670,7 @@ export async function execute(
         profile: state.profile,
       };
     }
-    
+
     // ✅ CRITICAL: Extract files from FileRegistry for state.files
     const files: Array<{ path: string; content: string; actionType: 'create' | 'edit' | 'append' | 'delete' }> = [];
     if (finalizeResult?.streamedFiles) {
@@ -778,7 +778,25 @@ export async function execute(
           .map(fp => `[file written to disk: ${fp}]`)
           .join('\n');
       }
-      
+
+      // dim-beating-brass RCA — "marker mimicry": the model can type the
+      // literal status text `[file written to disk: X]` instead of a real
+      // <file> tag, so nothing is written. `cleanFileContentFromResponse`
+      // strips real <file> bodies, so a marker SURVIVING in the cleaned text
+      // while ZERO files were streamed can only have been typed by the model.
+      const typedPhantomMarker =
+        streamedFilePaths.length === 0 &&
+        /\[file (?:written to disk|edited|appended):\s*[^\]]+\]/.test(cleanedResponse);
+      if (typedPhantomMarker) {
+        // Neutralize the hallucinated marker before it enters history — left
+        // intact, `compactTurns.extractFactsFromMessages` would later parse it
+        // as a genuine write and re-inject the false "already saved" belief.
+        cleanedResponse = cleanedResponse.replace(
+          /\[file (?:written to disk|edited|appended):\s*[^\]]+\]/g,
+          '(emitted marker text only — NO file was written)',
+        );
+      }
+
       // Thinking-only response: LLM produced a thinking block but no text/tools.
       // Preserve the thinking content so the next call has context and
       // enableThinking switches to false (isAfterToolCall becomes true).
@@ -789,24 +807,44 @@ export async function execute(
       if (cleanedResponse) {
         // Build re-entry message with specific file list so the LLM doesn't
         // have to search through history to find which files already exist.
-        const reentryParts = [
-          'Your previous response did not include any tool calls or <done>true</done>.',
-        ];
-        if (streamedFilePaths.length > 0) {
+        const reentryParts: string[] = [];
+        if (typedPhantomMarker) {
+          // Truthful correction. The previous "files already saved — do NOT
+          // recreate" guidance is exactly what spiralled the model on
+          // dim-beating-brass: it confirmed the false belief that typing the
+          // marker had saved the file. Tell it the truth and show the real tag.
+          reentryParts.push(
+            '⚠️ NO file was written. Your previous response contained literal text like',
+            '"[file written to disk: ...]" but NOT a real <file> tag.',
+            '',
+            'That bracket is a status RECORD the system shows AFTER a real tag is saved —',
+            'typing it yourself writes nothing. To create a file, your output must contain a',
+            'real tag whose first token is `<`:',
+            '',
+            '  <file path="src/...">...the full file content, verbatim...</file>',
+            '',
+            'Emit the real <file> tag now for the file you intended to write.',
+          );
+        } else {
+          reentryParts.push(
+            'Your previous response did not include any tool calls or <done>true</done>.',
+          );
+          if (streamedFilePaths.length > 0) {
+            reentryParts.push(
+              '',
+              `The following ${streamedFilePaths.length} file(s) are already saved to disk — do NOT recreate them:`,
+              ...streamedFilePaths.map(fp => `  - ${fp}`),
+            );
+          }
+          const doneHint = isRemediationTask
+            ? 'If you have applied all fixes from the remediation plan, output <done>true</done> now. Do NOT run build/test — a separate diagnostic phase re-verifies automatically.'
+            : 'If you have completed all work for this task, output <done>true</done> now.';
           reentryParts.push(
             '',
-            `The following ${streamedFilePaths.length} file(s) are already saved to disk — do NOT recreate them:`,
-            ...streamedFilePaths.map(fp => `  - ${fp}`),
+            doneHint,
+            'If there is remaining work, continue with NEW files only.',
           );
         }
-        const doneHint = isRemediationTask
-          ? 'If you have applied all fixes from the remediation plan, output <done>true</done> now. Do NOT run build/test — a separate diagnostic phase re-verifies automatically.'
-          : 'If you have completed all work for this task, output <done>true</done> now.';
-        reentryParts.push(
-          '',
-          doneHint,
-          'If there is remaining work, continue with NEW files only.',
-        );
 
         const newHistory = [
           ...nodeExecute,

--- a/packages/ant-cli/src/core/prompt/templates/jobs/shared/injections/output-tag-policy.md
+++ b/packages/ant-cli/src/core/prompt/templates/jobs/shared/injections/output-tag-policy.md
@@ -17,6 +17,16 @@ If you have something to say to the user, the first thing you write is
 opening a tag. That sentence has nowhere to go and disappears. Open the
 tag immediately.
 
+### Invariant 1b — Status markers are records, not actions
+
+After a `<file>`/`<edit>`/`<append>` tag is saved, the transcript may show
+it compacted to `[file written to disk: <path>]` (or `[file edited: …]` /
+`[file appended: …]`). That bracket line is the past **result** of a real
+tag — a read-only record that the file already exists. It is NOT a way to
+write a file: typing that bracket text yourself writes nothing. The only
+way to create or change a file is a real `<file>`/`<edit>`/`<append>` tag
+(first token `<`, per Invariant 1).
+
 ### Invariant 2 — No nesting across intent axes
 
 Tags from different intent axes MUST NOT nest inside each other.


### PR DESCRIPTION
dim-beating-brass RCA: the model could type the literal status marker "[file written to disk: X]" instead of a real <file> tag, so nothing was written. The re-entry message then said "files already saved - do NOT recreate", confirming the false belief and spiralling the model into a ~40-min loop until the global recursion ceiling. This is a separate defect from the recent re-read recursion fix (33d9acb), not a side effect of it.

Root cause is marker self-poisoning + misleading feedback, not a generic no-progress loop - so no new state/flags or per-node special-casing:

- execute: detect a typed phantom marker (a marker surviving the response cleaning while ZERO files were streamed can only have been typed by the model), neutralize it before it enters history so compactTurns.extractFactsFromMessages cannot parse the hallucination as a real write and re-inject the false "already saved" belief, and replace the misleading re-entry guidance with the truth ("NO file written - emit a real <file> tag").
- output-tag-policy: add Invariant 1b - the "[file written to disk: ...]" markers are read-only records of a saved tag, not a way to write a file.

tsc --noEmit clean; full suite 4095 tests pass.

<!--
Thanks for contributing to Ant!
Before opening this PR, please read CONTRIBUTING.md.
-->

## Summary

<!-- One or two sentences describing what this PR changes and why. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] CI / build / tooling

## Affected area

- [ ] `ant-cli` (backend / agents / LangGraph)
- [ ] `ant-ui` (frontend)
- [ ] `ant-shared` (cross-package types)
- [ ] Prompts / templates
- [ ] Docs (`docs/`)
- [ ] CI / build

## Test plan

<!--
How did you verify this works?

- Commands you ran (e.g. `pnpm test:cli`, `pnpm typecheck`).
- Manual scenarios you walked through.
- Screenshots or recordings for UI changes.
-->

## Linked issue

<!-- e.g. Closes #123 -->

## Checklist

- [ ] `pnpm build` succeeds locally (this also runs the tests).
- [ ] `pnpm typecheck` is clean.
- [ ] I added or updated tests when changing behaviour.
- [ ] I updated documentation (`docs/`, README, AGENTS.md) if my change affects users or contributors.
- [ ] No internal hostnames, incident codenames, or personal identifiers in this diff.
- [ ] If I touched prompts, I ran the relevant prompt-policy tests.
- [ ] Commit messages follow Conventional Commits (`feat: ...`, `fix: ...`).
