### PR TITLE
fix(plan/batch-split): promote single-session capacity axis to its ow…

### DIFF
--- a/packages/ant-cli/src/core/prompt/templates/jobs/code/nodes/plan/rules.md
+++ b/packages/ant-cli/src/core/prompt/templates/jobs/code/nodes/plan/rules.md
@@ -118,11 +118,7 @@ The task arrived with its scope already chosen at decomposition. Fan-out here is
 
 {{> jobs/code/shared/task-split-rubric }}
 
-### Single-session closure (plan-time check)
-
-One `batches[]` entry is one execute round. The observable signal is the slice's expected work volume — files touched, modules created, domain breadth. When that volume makes single-round closure unrealistic for this work, split — even if the coherence rubric above would otherwise bundle.
-
-This axis is orthogonal to coherence: the rubric decides *whether the work is separable*, this check decides *whether one session can hold it*. A coherent unit may still need to be split when single-session closure says so. When that happens, `parentReasoning` names single-session closure (not coherence) as the concrete benefit.
+{{> jobs/code/shared/plan-batch-capacity }}
 
 ### Scheduling fields — REQUIRED per batch
 

--- a/packages/ant-cli/src/core/prompt/templates/jobs/code/shared/plan-batch-capacity.md
+++ b/packages/ant-cli/src/core/prompt/templates/jobs/code/shared/plan-batch-capacity.md
@@ -1,0 +1,28 @@
+## Single-session capacity (plan-time only)
+
+One `batches[]` entry executes inside a single LangGraph subgraph invocation bounded by the environment-tunable `RECURSION_LIMIT`. The step ceiling is not the LLM-round ceiling — multiple nodes intervene per round, so the usable LLM-round budget is a fraction of the step ceiling.
+
+### Orthogonality
+
+This axis is orthogonal to the separability rubric above. The rubric decides whether the work *can* be split. This axis decides whether the work *fits* in one session. When this axis fires, split — even when the separability rubric supports bundling. When that happens, `parentReasoning` names single-session capacity (not coherence) as the concrete benefit.
+
+### Cost model
+
+The dominant per-file cost is the **reads required before the edit can be written**. A file edited blindly — the recipe applies without consulting the file's current contents or any reference file — costs minimally. A file whose edit depends on reading the file's existing state, or on consulting sibling references (paired types, design-system components, adjacent markup), costs proportionally more. Search and listing operations add overhead where they materially shape the budget.
+
+The honest per-file cost is what *this* batch in *this* codebase actually needs — not a generic table. The planner's own context-aware judgement is the signal.
+
+### When this axis fires
+
+When the sum of per-file costs across the batch approaches the usable round budget for one session, capacity binds. The threshold is the planner's own honest estimate against the prevailing `RECURSION_LIMIT`, sourced from the directive's observable surface — not a fixed number.
+
+### Articulation — fail-closed constraint
+
+A bundle decision MUST articulate the per-file cost shape in `parentReasoning`: name, per file or per file group, the reads required before the edit and why the combined cost fits in one session. Two articulation failures rule out the bundle:
+
+- `parentReasoning` does not name per-file cost shape — the planner skipped the capacity check. Split.
+- The bundle's only defense is "the recipe is uniform across locations" without addressing whether each location's existing state must be read first. Split — and re-run Authorship density's per-location-state self-check, because uniform-recipe defenses are the failure mode this axis exists to catch.
+
+### Blind-spot reminder
+
+**Pattern**: *Recipe uniformity hides per-location inspection.* Multiple locations appear to share one transformation rule, but each location requires its own read of existing state (markup, paired types, sibling references) before the rule can be applied correctly. Surface uniformity of the recipe is necessary but not sufficient for the mechanical case in Authorship density above — this pattern is the failure mode where the recipe looks mechanical but the work is rewrite-each-X. When you recognise it, the capacity articulation above is required even when 1–4 of the rubric support bundling.

--- a/packages/ant-cli/tests/__generated__/template-matrix.json
+++ b/packages/ant-cli/tests/__generated__/template-matrix.json
@@ -1058,6 +1058,11 @@
       "partial-ref"
     ]
   },
+  "jobs/code/shared/plan-batch-capacity": {
+    "sources": [
+      "partial-ref"
+    ]
+  },
   "jobs/code/shared/task-split-rubric": {
     "sources": [
       "partial-ref"

--- a/packages/ant-cli/tests/plan-fanout-prompt.test.ts
+++ b/packages/ant-cli/tests/plan-fanout-prompt.test.ts
@@ -28,9 +28,14 @@ const RUBRIC_PATH = path.resolve(
   __dirname,
   '../src/core/prompt/templates/jobs/code/shared/task-split-rubric.md',
 );
+const CAPACITY_PATH = path.resolve(
+  __dirname,
+  '../src/core/prompt/templates/jobs/code/shared/plan-batch-capacity.md',
+);
 
 const RULES = readFileSync(RULES_PATH, 'utf8');
 const RUBRIC = readFileSync(RUBRIC_PATH, 'utf8');
+const CAPACITY = readFileSync(CAPACITY_PATH, 'utf8');
 
 describe('plan/rules.md — REQUIRED markers on LLM-authored semantic fields', () => {
   it('create[].name is annotated REQUIRED with a noun-phrase exemplar', () => {
@@ -78,14 +83,36 @@ describe('plan/rules.md — fan-out is LLM-explicit, default is bundle', () => {
     expect(RULES).not.toMatch(/##\s+🌿\s+(OPTIONAL|PROACTIVE) FAN-OUT/);
   });
 
-  it('plan-time single-session-closure check is rendered alongside the shared rubric', () => {
-    expect(RULES).toMatch(/Single-session closure \(plan-time check\)/);
-    expect(RULES).toMatch(/one execute round/);
-    expect(RULES).toMatch(/orthogonal to coherence/);
+  it('plan-time single-session-capacity partial is rendered alongside the shared rubric', () => {
+    // Capacity axis is now a standalone partial (plan-only SSOT), kept
+    // separate from the shared semantic rubric so decompose can render the
+    // rubric without inheriting the plan-time capacity axis.
+    expect(RULES).toMatch(/{{>\s+jobs\/code\/shared\/plan-batch-capacity\s+}}/);
+    // Inline legacy wording must not survive — the partial is the only SSOT.
+    expect(RULES).not.toMatch(/Single-session closure \(plan-time check\)/);
+    expect(RULES).not.toMatch(/orthogonal to coherence/);
+  });
+
+  it('plan-batch-capacity partial states the plan-only orthogonal axis with articulation contract', () => {
+    expect(CAPACITY).toMatch(/Single-session capacity \(plan-time only\)/);
+    expect(CAPACITY).toMatch(/orthogonal/i);
+    expect(CAPACITY).toMatch(/per-file cost/i);
+    expect(CAPACITY).toMatch(/recipe uniformity/i);
+    expect(CAPACITY).toMatch(/parentReasoning/);
   });
 
   it('renders the shared task-split-rubric partial (SSOT with decompose)', () => {
     expect(RULES).toMatch(/{{>\s+jobs\/code\/shared\/task-split-rubric\s+}}/);
+  });
+
+  it('decompose does NOT receive the plan-batch-capacity partial (token-weight protection)', () => {
+    const DECOMPOSE_OUTPUT_UNIT_PATH = path.resolve(
+      __dirname,
+      '../src/core/prompt/templates/jobs/code/nodes/decompose/variants/default/output-unit-splitting.md',
+    );
+    const DECOMPOSE = readFileSync(DECOMPOSE_OUTPUT_UNIT_PATH, 'utf8');
+    expect(DECOMPOSE).not.toMatch(/plan-batch-capacity/);
+    expect(DECOMPOSE).not.toMatch(/Single-session capacity/);
   });
 
   it('states that the system does NOT auto-convert flat plans', () => {


### PR DESCRIPTION
…n partial

dim-beating-brass RCA continued: ui-instructor failed with recursion limit even after the marker-mimicry (efbac721) and re-read (33d9acb) fixes were deployed. Its 102 LLM rounds were not a pathological loop — 193 tool calls mostly hit distinct files (81 read / 53 list / 42 edit) doing real styling work across 16 distinct teacher-track pages. Root cause is plan-time: batch-split returned batchSplitOccurred:false for ui-instructor, so a task that needed to fit ~12 rounds/file × 16 files into one 200-step recursion budget ran as a monolith and crashed.

The capacity axis that should have caught this DID exist in plan/rules.md lines 121-125 ("Single-session closure (plan-time check)"), but as a 5-line inline subsection — not a partial — while the separability rubric (1-4 axes) was a fully-promoted shared partial. Authority asymmetry: the LLM applied the rubric's "recipe uniformity = negative signal" and missed the inline capacity check that was supposed to override it for ui-instructor's volume.

Decompose and plan deliberately split batch-split responsibility: decompose runs one big LLM call where output-token weight matters, so decompose only carries the semantic separability rubric. Capacity reasoning belongs at plan-time where per-task LLM calls have room and where the actual file surface is observable. The fix preserves that separation.

- New partial templates/jobs/code/shared/plan-batch-capacity.md: plan-only SSOT for the capacity axis. Written FPOP-style (principles over examples, what over how) so the LLM keeps autonomous judgement — no magic round counts, no fixed file thresholds, no 5-step procedure. The fail-closed bite is in the Articulation constraint: parentReasoning MUST name per-file cost shape; bundles defended only by "recipe uniformity" without addressing per-location reads are treated as articulation failures and split. Includes the blind-spot pattern (recipe uniformity hiding per-location inspection) that the ui-instructor case exemplifies.
- plan/rules.md: replaces the 5 inline lines with a {{> }} include, kept inside the {{#if feature/ui/design-system}} gate so other task types are not exposed (SBS).
- decompose, plan variants (error / verification / test-code) untouched: verification/error batches are root-cause grouping, test-code already carries its own capacity threshold + lineage counter — including the new partial there would violate MECE.
- plan-fanout-prompt.test.ts: guard updated to assert the include + the new partial's contract; adds a regression guard that decompose does NOT receive the capacity partial (token-weight protection).

tsc --noEmit clean; full suite 4097 tests pass.

<!--
Thanks for contributing to Ant!
Before opening this PR, please read CONTRIBUTING.md.
-->

## Summary

<!-- One or two sentences describing what this PR changes and why. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] CI / build / tooling

## Affected area

- [ ] `ant-cli` (backend / agents / LangGraph)
- [ ] `ant-ui` (frontend)
- [ ] `ant-shared` (cross-package types)
- [ ] Prompts / templates
- [ ] Docs (`docs/`)
- [ ] CI / build

## Test plan

<!--
How did you verify this works?

- Commands you ran (e.g. `pnpm test:cli`, `pnpm typecheck`).
- Manual scenarios you walked through.
- Screenshots or recordings for UI changes.
-->

## Linked issue

<!-- e.g. Closes #123 -->

## Checklist

- [ ] `pnpm build` succeeds locally (this also runs the tests).
- [ ] `pnpm typecheck` is clean.
- [ ] I added or updated tests when changing behaviour.
- [ ] I updated documentation (`docs/`, README, AGENTS.md) if my change affects users or contributors.
- [ ] No internal hostnames, incident codenames, or personal identifiers in this diff.
- [ ] If I touched prompts, I ran the relevant prompt-policy tests.
- [ ] Commit messages follow Conventional Commits (`feat: ...`, `fix: ...`).
