### PR TITLE
fix(plan/batch-split): reframe capacity axis to per-task involvement …

### DIFF
--- a/packages/ant-cli/src/core/prompt/templates/jobs/code/shared/plan-batch-capacity.md
+++ b/packages/ant-cli/src/core/prompt/templates/jobs/code/shared/plan-batch-capacity.md
@@ -1,28 +1,35 @@
 ## Single-session capacity (plan-time only)
 
-One `batches[]` entry executes inside a single LangGraph subgraph invocation bounded by the environment-tunable `RECURSION_LIMIT`. The step ceiling is not the LLM-round ceiling — multiple nodes intervene per round, so the usable LLM-round budget is a fraction of the step ceiling.
+A `batches[]` entry that you do NOT fan out further runs as one execute cycle — one task with a bounded recursion budget. A task whose **involvement scope** is too large for one cycle exhausts the budget before completion, and recursion-limit termination is unrecoverable. Such tasks must be split at plan time — *regardless* of the prevailing budget value. The principle is intrinsic to the task's shape, not arithmetic against a number.
 
 ### Orthogonality
 
-This axis is orthogonal to the separability rubric above. The rubric decides whether the work *can* be split. This axis decides whether the work *fits* in one session. When this axis fires, split — even when the separability rubric supports bundling. When that happens, `parentReasoning` names single-session capacity (not coherence) as the concrete benefit.
+This axis is orthogonal to the separability rubric above. The rubric decides whether the work *can* be split. This axis decides whether the task's involvement scope *is too large* for one cycle. When this axis fires, split — even when the separability rubric supports bundling. When that happens, `parentReasoning` names single-session capacity (not coherence) as the concrete benefit.
 
-### Cost model
+The rubric's negative signal "many files alone — informational" applies to *separability* (count alone does not make work conceptually independent). It does **not** override this axis: a task's involvement scope still adds to capacity bulk even when its parts share one investigation conceptually.
 
-The dominant per-file cost is the **reads required before the edit can be written**. A file edited blindly — the recipe applies without consulting the file's current contents or any reference file — costs minimally. A file whose edit depends on reading the file's existing state, or on consulting sibling references (paired types, design-system components, adjacent markup), costs proportionally more. Search and listing operations add overhead where they materially shape the budget.
+### The task's involvement scope
 
-The honest per-file cost is what *this* batch in *this* codebase actually needs — not a generic table. The planner's own context-aware judgement is the signal.
+The unit of measurement is the **task as a whole**, not any individual file. A task's involvement scope is the union of every file the task will *read*, *modify*, *create*, *delete*, or *discover* before it can emit `<done>`. Three dimensions describe this scope; each can fire alone, and any two reinforce each other:
 
-### When this axis fires
+- **Modification breadth** — the set of files the task will create / modify / delete. Many files compound: each location still consumes its own cycle round to author the edit, even when the edit itself is trivial.
+- **Reference depth** — the files the task must *read* per modification to inform the edit: the modified file's existing state, paired types, sibling references (design-system components, adjacent markup, related modules), upstream consumers. Each per-modification read is its own cycle round; depth compounds across the modification set.
+- **Exploration breadth** — the unknown landscape the task must *discover* before any modification can begin: which design-system components exist, which modules house relevant utilities, which directory layout serves the target tech stack. Exploration cost is orthogonal to the other two — a task with a small modification breadth can still burn many rounds listing directories to find the right files.
 
-When the sum of per-file costs across the batch approaches the usable round budget for one session, capacity binds. The threshold is the planner's own honest estimate against the prevailing `RECURSION_LIMIT`, sourced from the directive's observable surface — not a fixed number.
+A task's involvement scope is too large for one cycle when ANY single dimension is large *or* two dimensions are even moderately large in combination. The judgement is qualitative. Do NOT estimate round counts, do NOT compare against a numeric ceiling, do NOT compute `breadth × depth + exploration`. Look at the task's overall scope, recognise which dimensions are heavy, decide.
 
 ### Articulation — fail-closed constraint
 
-A bundle decision MUST articulate the per-file cost shape in `parentReasoning`: name, per file or per file group, the reads required before the edit and why the combined cost fits in one session. Two articulation failures rule out the bundle:
+A bundle decision MUST name, in `parentReasoning`, the task's character along ALL THREE dimensions of involvement scope (modification breadth / reference depth / exploration breadth) and why none of them — and no combination of them — makes the task's scope too large for one cycle. Three articulation failures rule out the bundle:
 
-- `parentReasoning` does not name per-file cost shape — the planner skipped the capacity check. Split.
-- The bundle's only defense is "the recipe is uniform across locations" without addressing whether each location's existing state must be read first. Split — and re-run Authorship density's per-location-state self-check, because uniform-recipe defenses are the failure mode this axis exists to catch.
+- `parentReasoning` does not characterise one or more of the three dimensions. The planner skipped at least one capacity check. Split.
+- The bundle's only reference-depth defense is "the recipe is uniform across locations" without addressing whether each modification's existing state and references must be read first. Split — and re-run Authorship density's per-location-state self-check, because uniform-recipe defenses are the failure mode this axis exists to catch.
+- The bundle's exploration defense ignores how much of the codebase landscape the planner has not yet observed. If the task will require listing many directories or searching for unfamiliar symbols before any modification can be authored, exploration is large regardless of how few files the task ultimately modifies. Split.
 
-### Blind-spot reminder
+### Blind-spot reminders
 
-**Pattern**: *Recipe uniformity hides per-location inspection.* Multiple locations appear to share one transformation rule, but each location requires its own read of existing state (markup, paired types, sibling references) before the rule can be applied correctly. Surface uniformity of the recipe is necessary but not sufficient for the mechanical case in Authorship density above — this pattern is the failure mode where the recipe looks mechanical but the work is rewrite-each-X. When you recognise it, the capacity articulation above is required even when 1–4 of the rubric support bundling.
+**Pattern A — Recipe uniformity hides reference depth.** A task's modifications appear to share one transformation rule, but each modification still requires its own reads of existing state (markup, paired types, sibling references) before the rule can be applied correctly. Surface uniformity of the recipe is necessary but not sufficient for the mechanical case in Authorship density above — when each modification has its own existing state to consult, the task's reference depth is real.
+
+**Pattern B — Unknown landscape hides exploration breadth.** When the task's recipe references a library, package, or design-system whose API surface the planner has not yet observed, the implementer will burn many cycle rounds listing directories and searching for symbols before any modification is possible. A directive like "apply design-system tokens across all instructor screens" sounds reference-depth-light, but if the planner does not yet know which design-system components exist for each visual element, the discovery work is the bulk — not the edits.
+
+**Pattern C — Modification count alone seems harmless.** A task whose modifications are individually trivial still consumes one cycle round per modification to author the edit. "These are all one-line changes" does not collapse N modifications into one cycle round.

--- a/packages/ant-cli/tests/plan-fanout-prompt.test.ts
+++ b/packages/ant-cli/tests/plan-fanout-prompt.test.ts
@@ -96,9 +96,45 @@ describe('plan/rules.md — fan-out is LLM-explicit, default is bundle', () => {
   it('plan-batch-capacity partial states the plan-only orthogonal axis with articulation contract', () => {
     expect(CAPACITY).toMatch(/Single-session capacity \(plan-time only\)/);
     expect(CAPACITY).toMatch(/orthogonal/i);
-    expect(CAPACITY).toMatch(/per-file cost/i);
-    expect(CAPACITY).toMatch(/recipe uniformity/i);
     expect(CAPACITY).toMatch(/parentReasoning/);
+  });
+
+  it('plan-batch-capacity partial unit is per-task involvement scope (NOT per-file)', () => {
+    // The capacity decision is about the TASK as a whole — the union of
+    // files it will read, modify, create, delete, or discover — not just
+    // files it edits. Edit count alone was the framing that let
+    // ui-instructor slip through: it had only ~16 modifications but 81
+    // reads + 53 list_files for design-system landscape discovery.
+    expect(CAPACITY).toMatch(/involvement scope/i);
+    expect(CAPACITY).toMatch(/task as a whole/i);
+  });
+
+  it('plan-batch-capacity partial covers all three dimensions of bulk', () => {
+    // Modification breadth, reference depth, exploration breadth — each
+    // can trigger split alone; any two reinforce each other. Reference
+    // depth alone (the prior framing) misses tasks that overflow on
+    // discovery cost (the ui-instructor failure mode).
+    expect(CAPACITY).toMatch(/modification breadth/i);
+    expect(CAPACITY).toMatch(/reference depth/i);
+    expect(CAPACITY).toMatch(/exploration breadth/i);
+    // All three must be articulated to defend a bundle.
+    expect(CAPACITY).toMatch(/ALL THREE dimensions/i);
+  });
+
+  it('plan-batch-capacity partial is budget-value-agnostic (FPOP — intrinsic principle, not arithmetic)', () => {
+    // The capacity decision is qualitative, not computational. The LLM
+    // recognises bulky scope intrinsically; it does NOT measure cost
+    // against a remaining budget number. Anchoring the partial to a
+    // budget value (RECURSION_LIMIT magic name OR a runtime-injected
+    // remaining-budget variable) reframes the principle as arithmetic
+    // and invites both miscounting and "this is under the ceiling so
+    // bundle" rationalisation — the failure mode this axis exists to
+    // catch. Keep the partial purely intrinsic.
+    expect(CAPACITY).not.toMatch(/RECURSION_LIMIT/);
+    expect(CAPACITY).not.toMatch(/{{remainingRecursionBudget}}/);
+    // Explicitly forbid budget-comparison framing.
+    expect(CAPACITY).toMatch(/regardless.*of.*the.*(?:prevailing\s+)?budget/i);
+    expect(CAPACITY).toMatch(/do NOT.*(?:compare|compute|estimate)/i);
   });
 
   it('renders the shared task-split-rubric partial (SSOT with decompose)', () => {


### PR DESCRIPTION
…scope

Sharpening pass on the capacity partial. Two defects in the first draft, both caught by re-examining the dim-beating-brass ui-instructor data:

1. Framing was budget-arithmetic. Earlier revisions referenced `RECURSION_LIMIT` (a magic name the LLM cannot resolve) or injected the runtime `{{remainingRecursionBudget}}` value. Both framings push the LLM toward `K = Σ cost vs ceiling` arithmetic — the failure mode that lets a planner rationalise bundling whenever the estimate happens to sit under the ceiling. The principle is intrinsic to the work's shape: regardless of budget value, bulky work splits. No numbers, no comparisons.

2. Unit was per-file (specifically per-edit-file), but ui-instructor's actual overflow was driven by reads and exploration, not edits: 16 modifications vs 81 reads vs 53 list_files. The LLM-burning bulk was the design-system landscape discovery, not the edits. Per-file framing hid this entire axis from the planner.

The corrected unit is the task's involvement scope — the union of files the task will read, modify, create, delete, or discover before emitting <done>. Three orthogonal dimensions describe it:

- Modification breadth — files the task will create / modify / delete.
- Reference depth — files the task must read per modification (paired types, sibling references, design-system components, upstream consumers).
- Exploration breadth — unknown landscape the task must discover (which components / modules / directory layouts exist) before any modification can be authored.

Any one dimension can trigger split alone; any two reinforce. The bundle decision must articulate ALL THREE in `parentReasoning`; missing any one is articulation failure → split. Blind-spot reminders name three failure patterns:

- A (depth): recipe uniformity hides per-location inspection
- B (exploration): unknown landscape hides discovery cost — the ui-instructor failure mode specifically
- C (breadth): modification count alone seems harmless

Test guards updated to enforce the per-task framing, the three-dimension coverage, and the budget-value-agnostic principle (no `RECURSION_LIMIT` magic, no `{{remainingRecursionBudget}}` arithmetic anchor).

tsc --noEmit clean; full suite 4100 tests pass.

<!--
Thanks for contributing to Ant!
Before opening this PR, please read CONTRIBUTING.md.
-->

## Summary

<!-- One or two sentences describing what this PR changes and why. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] CI / build / tooling

## Affected area

- [ ] `ant-cli` (backend / agents / LangGraph)
- [ ] `ant-ui` (frontend)
- [ ] `ant-shared` (cross-package types)
- [ ] Prompts / templates
- [ ] Docs (`docs/`)
- [ ] CI / build

## Test plan

<!--
How did you verify this works?

- Commands you ran (e.g. `pnpm test:cli`, `pnpm typecheck`).
- Manual scenarios you walked through.
- Screenshots or recordings for UI changes.
-->

## Linked issue

<!-- e.g. Closes #123 -->

## Checklist

- [ ] `pnpm build` succeeds locally (this also runs the tests).
- [ ] `pnpm typecheck` is clean.
- [ ] I added or updated tests when changing behaviour.
- [ ] I updated documentation (`docs/`, README, AGENTS.md) if my change affects users or contributors.
- [ ] No internal hostnames, incident codenames, or personal identifiers in this diff.
- [ ] If I touched prompts, I ran the relevant prompt-policy tests.
- [ ] Commit messages follow Conventional Commits (`feat: ...`, `fix: ...`).
