### PR TITLE
fix(context): preserve chunked reads across compaction + gate test-co…

### DIFF
--- a/packages/ant-cli/src/agents/architect/graph/code/tasks/test-code/hooks/scheduling.ts
+++ b/packages/ant-cli/src/agents/architect/graph/code/tasks/test-code/hooks/scheduling.ts
@@ -2,9 +2,13 @@
  * test-code/hooks/scheduling.ts — TaskSchedulingHook
  *
  * Consumer flag (test-code task is BLOCKED by which barrier):
- *   - preTestgenBarrier — test-code generation waits until the feature
- *     + setup work it is testing against is complete; otherwise the
- *     generator races against still-moving source files.
+ *   - preTestgenBarrier — test-code generation waits until the setup +
+ *     feature + ui work it is testing against is complete; otherwise the
+ *     generator races against still-moving source / view files. The
+ *     producers that activate `hasPreTestgenWork` live on each upstream
+ *     bundle's `scheduling.blocksTestgen` flag (`setup` + `feature` +
+ *     `ui`). ui was added so tests target fully-built views, not
+ *     half-rendered components.
  *
  * Producer flag (test-code work ACTIVATES this barrier for other types):
  *   - blocksDoc — doc tasks wait until test-code work finishes so the
@@ -12,8 +16,9 @@
  *
  * Intentionally unpublished:
  *   - preUiBarrier / preDocBarrier / preIntegrationBarrier — test-code
- *     only blocks on testgen; it runs after feature/setup but does not
- *     need to wait on ui / doc / integration work.
+ *     consumes ONLY the testgen barrier. Note it still waits for ui, but
+ *     via ui's `blocksTestgen` producer (→ the testgen barrier), NOT by
+ *     consuming a preUiBarrier here. It does not wait on doc / integration.
  *   - blocksUi / blocksTestgen / blocksIntegration — test-code does not
  *     gate those barriers. In particular blocksTestgen=false prevents
  *     self-blocking (a test-code task would otherwise block sibling

--- a/packages/ant-cli/src/agents/architect/graph/code/tasks/ui/hooks/scheduling.ts
+++ b/packages/ant-cli/src/agents/architect/graph/code/tasks/ui/hooks/scheduling.ts
@@ -1,5 +1,5 @@
 /**
- * ui/hooks/scheduling.ts — TaskSchedulingHook (consumer-only)
+ * ui/hooks/scheduling.ts — TaskSchedulingHook
  *
  * UI tasks render the view layer from `uiSections` + design tokens and
  * must wait for foundation (`setup`) and feature scaffolding before
@@ -12,10 +12,22 @@
  *
  * Who activates `hasPreUiWork` is a producer-side concern and lives on
  * each upstream bundle's `scheduling.blocksUi` flag (currently:
- * `setup` + `feature`). UI itself never produces a barrier — it is a
- * barrier sink only, so no `blocksUi / blocksTestgen / blocksDoc /
- * blocksIntegration` flags are exported here. The registry test locks
- * this invariant.
+ * `setup` + `feature`).
+ *
+ * Producer flag (ui work ACTIVATES this barrier for other types):
+ *   - blocksTestgen — test-code tasks wait for ui work to finish so the
+ *     generated tests target fully-built views, not half-rendered
+ *     components. Added alongside setup/feature so test-code runs only
+ *     after ALL ordinary implementation (feature + ui) is complete.
+ *     doc is gated transitively (doc waits on test-code via blocksDoc).
+ *
+ * Intentionally unpublished:
+ *   - blocksUi / blocksDoc / blocksIntegration — ui does not gate those
+ *     barriers (no self-block on ui; doc reaches ui transitively through
+ *     test-code; integration is a feature-band concern). The registry
+ *     test locks each of these to `undefined`.
  */
 
 export const preUiBarrier = true;
+
+export const blocksTestgen = true;

--- a/packages/ant-cli/src/agents/architect/graph/code/tasks/ui/index.ts
+++ b/packages/ant-cli/src/agents/architect/graph/code/tasks/ui/index.ts
@@ -6,6 +6,11 @@
  * Hooks published:
  *   - scheduling.preUiBarrier   — block ui work while `blocksUi`
  *                                 producers (setup / feature) run.
+ *   - scheduling.blocksTestgen  — producer: test-code tasks wait for ui
+ *                                 work to finish so generated tests
+ *                                 target fully-built views (alongside
+ *                                 setup / feature). doc is gated
+ *                                 transitively (doc waits on test-code).
  *   - conversations.convKey     — per-task conversation scope (pre-wiring;
  *                                 phase layer still shares
  *                                 `CONV_KEYS.NODE_EXECUTE`).
@@ -18,9 +23,9 @@
  *     so no ui-specific plan variant template or template-var override
  *     is required. There is no `plan/variants/ui/` template and no
  *     planGeneration.ts branch to port.
- *   - scheduling producer flags (`blocksUi / blocksTestgen / blocksDoc /
- *     blocksIntegration`) — UI is a barrier sink only; it does not
- *     activate barriers for other task types.
+ *   - scheduling producer flags `blocksUi / blocksDoc / blocksIntegration`
+ *     — ui gates ONLY testgen (no self-block on ui; doc reaches ui
+ *     transitively via test-code; integration is a feature-band concern).
  *
  * Phase-layer `task.type === 'ui'` residuals were resolved in T6b-κ:
  *   - `nodes/decompose/responseParser.ts deriveArtifactPolicy` — the
@@ -33,7 +38,7 @@
  * presence, not task-type literals).
  */
 
-import { preUiBarrier } from './hooks/scheduling';
+import { preUiBarrier, blocksTestgen } from './hooks/scheduling';
 import { convKey } from './hooks/conversations';
 import { extraTemplateVars as planExtraTemplateVars } from './hooks/plan';
 import { composeBundle } from '../_shared/verify';
@@ -54,7 +59,7 @@ export const hooks = composeBundle({
     plan: { extraTemplateVars: planExtraTemplateVars },
   },
   taskTypeSpecific: {
-    scheduling: { preUiBarrier },
+    scheduling: { preUiBarrier, blocksTestgen },
     conversations: { convKey },
   },
 });

--- a/packages/ant-cli/src/core/context/compactTurns.ts
+++ b/packages/ant-cli/src/core/context/compactTurns.ts
@@ -119,39 +119,65 @@ function stringifyToolResultContent(content: string | MessageContentBlock[]): st
   return '';
 }
 
+interface PreservedRead {
+  path: string;
+  /** Human-readable range suffix, e.g. " (lines 140-160)"; "" for whole-file. */
+  label: string;
+  content: string;
+}
+
+/** Range descriptor for a read_file tool_use, derived from its input. */
+function readRangeOf(input: Record<string, any> | undefined): { rangeKey: string; label: string } {
+  const s = input?.startLine;
+  const e = input?.endLine;
+  const hasS = typeof s === 'number';
+  const hasE = typeof e === 'number';
+  if (!hasS && !hasE) return { rangeKey: '', label: '' }; // whole-file read
+  const sv = hasS ? String(s) : '';
+  const ev = hasE ? String(e) : '';
+  return { rangeKey: `${sv}-${ev}`, label: ` (lines ${sv}-${ev})` };
+}
+
 /**
- * Walk messages in order and return, per file path, the content of its MOST
- * RECENT `read_file` that has NO later `edit_file`/`create_file` on the same
- * path.
+ * Walk messages in order and return, per (file path, read range), the content
+ * of its MOST RECENT `read_file` that has NO later `edit_file`/`create_file`
+ * on the same path.
  *
- * Why: the old compaction dropped read content entirely (path-only summary),
- * so once history passed the threshold the model could no longer see files it
- * had read and re-read them in a loop until the recursion budget was burned
- * (dim-beating-brass RCA). Preserving the latest read lets the model keep its
- * context.
+ * Why keyed by (path, range), not path alone: the old compaction dropped read
+ * content entirely (path-only summary), so the model re-read files in a loop
+ * until the recursion budget burned (dim-beating-brass RCA). The first fix
+ * preserved the latest read PER PATH — but a large file read in multiple
+ * line-range chunks then collapsed to its last chunk, so the model lost the
+ * earlier chunks and re-read them: the same loop, recurring for ranged reads
+ * (grave-bolting-cloud RCA). Keying by (path, range) preserves EVERY distinct
+ * chunk. A whole-file read is the range=none point of the same key space, so
+ * reading a file whole twice still dedups to latest — identical to the prior
+ * path-only behaviour, no separate compatibility branch.
  *
- * Staleness-safe: a read followed by an edit/create of the same path is
- * dropped here (the edit / on-disk state is the truth, surfaced via the
+ * Staleness-safe: an edit/create of a path drops ALL preserved ranges of that
+ * path (the edit / on-disk state is the truth, surfaced via the
  * `[file edited/written: …]` markers), so we never resurrect pre-edit content.
- * Reads invalidated only by a `run_command` (formatter/codegen) are left to a
- * normal re-read — that is the legitimate re-read case, not thrash.
  */
-function extractLatestReadContent(messages: ConversationMessage[]): Map<string, string> {
-  const toolUseById = new Map<string, { name: string; path: string }>();
-  const latestRead = new Map<string, string>();
+function extractLatestReadContent(messages: ConversationMessage[]): Map<string, PreservedRead> {
+  const toolUseById = new Map<string, { name: string; path: string; rangeKey: string; label: string }>();
+  const preserved = new Map<string, PreservedRead>();
 
   for (const msg of messages) {
     if (!Array.isArray(msg.content)) continue;
     for (const block of msg.content) {
       if (block.type === 'tool_use' && block.name) {
-        const path = (block.input as Record<string, any>)?.path;
+        const input = block.input as Record<string, any> | undefined;
+        const path = input?.path;
         const pathStr = typeof path === 'string' ? path : '';
         if (typeof block.id === 'string') {
-          toolUseById.set(block.id, { name: block.name, path: pathStr });
+          const { rangeKey, label } = readRangeOf(input);
+          toolUseById.set(block.id, { name: block.name, path: pathStr, rangeKey, label });
         }
-        // A mutation invalidates any prior preserved read of that path.
+        // A mutation invalidates ALL preserved ranges of that path.
         if ((block.name === 'edit_file' || block.name === 'create_file') && pathStr) {
-          latestRead.delete(pathStr);
+          for (const [key, entry] of preserved) {
+            if (entry.path === pathStr) preserved.delete(key);
+          }
         }
       } else if (block.type === 'tool_result') {
         const origin = block.tool_use_id ? toolUseById.get(block.tool_use_id) : undefined;
@@ -159,28 +185,33 @@ function extractLatestReadContent(messages: ConversationMessage[]): Map<string, 
         const path = origin?.path;
         if (toolName === 'read_file' && path && !block.is_error) {
           const text = stringifyToolResultContent(block.content);
-          if (text) latestRead.set(path, text); // re-set moves to latest content
+          if (text) {
+            // (path, range) key — distinct chunks coexist; same chunk re-read
+            // moves to latest content.
+            const key = JSON.stringify([path, origin?.rangeKey ?? '']);
+            preserved.set(key, { path, label: origin?.label ?? '', content: text });
+          }
         }
       }
     }
   }
-  return latestRead;
+  return preserved;
 }
 
 /**
  * Render the preserved read contents as a labelled block appended to the
  * post-compaction user message, with an explicit do-not-re-read directive.
  */
-function buildPreservedReadsText(latestReads: Map<string, string>): string {
-  if (latestReads.size === 0) return '';
+function buildPreservedReadsText(preserved: Map<string, PreservedRead>): string {
+  if (preserved.size === 0) return '';
   const parts: string[] = [
     'Current contents of files already read this task (deduplicated to the ' +
-    'latest read of each; files later edited/created are omitted here and ' +
+    'latest read of each path+range; files later edited/created are omitted here and ' +
     'reflected by the [file written/edited] markers above). These remain in ' +
     'your context — DO NOT call read_file on them again:',
   ];
-  for (const [path, content] of latestReads) {
-    parts.push(`\n===== ${path} =====\n${content}`);
+  for (const { path, label, content } of preserved.values()) {
+    parts.push(`\n===== ${path}${label} =====\n${content}`);
   }
   return parts.join('\n');
 }

--- a/packages/ant-cli/tests/core/context/compactTurns-read-retention.test.ts
+++ b/packages/ant-cli/tests/core/context/compactTurns-read-retention.test.ts
@@ -34,6 +34,14 @@ function editTurn(id: string, path: string): ConversationMessage[] {
   ];
 }
 
+function readRangeTurn(id: string, path: string, content: string, startLine: number, endLine: number): ConversationMessage[] {
+  const pad = ' padding'.repeat(40);
+  return [
+    { role: 'assistant', content: [{ type: 'tool_use', id, name: 'read_file', input: { path, startLine, endLine } }] as MessageContentBlock[] },
+    { role: 'user', content: [{ type: 'tool_result', tool_use_id: id, tool_name: 'read_file', content: content + pad }] as MessageContentBlock[] },
+  ];
+}
+
 /** Flatten all text out of a compacted message list. */
 function allText(messages: ConversationMessage[]): string {
   return messages
@@ -83,5 +91,56 @@ describe('compactTurns — read-content preservation', () => {
 
   it('includes a do-not-re-read directive', () => {
     expect(text.toLowerCase()).toContain('do not call read_file');
+  });
+});
+
+/**
+ * Chunked (ranged) read preservation — grave-bolting-cloud RCA.
+ *
+ * The path-only/latest-per-path scheme collapsed a large file read in multiple
+ * line-range chunks to its LAST chunk, so the model lost the earlier chunks and
+ * re-read them: the dim-beating-brass loop, recurring for ranged reads. Keying
+ * preserved reads by (path, range) keeps every distinct chunk.
+ */
+describe('compactTurns — chunked (ranged) read preservation', () => {
+  it('preserves ALL distinct line-range chunks of one file (no chunk loss)', () => {
+    const history: ConversationMessage[] = [
+      ...readRangeTurn('r1', 'src/big.ts', 'CHUNK_ONE', 1, 50),
+      ...readRangeTurn('r2', 'src/big.ts', 'CHUNK_TWO', 51, 100),
+      ...readRangeTurn('r3', 'src/big.ts', 'CHUNK_THREE', 101, 150),
+      { role: 'assistant', content: [{ type: 'text', text: 'final hot turn' }] as MessageContentBlock[] },
+    ];
+    const { compacted, wasCompacted } = compactTurns(history, 50, 1);
+    const text = allText(compacted);
+    expect(wasCompacted).toBe(true);
+    // All three chunks survive — the prior latest-per-path scheme kept only CHUNK_THREE.
+    expect(text).toContain('CHUNK_ONE');
+    expect(text).toContain('CHUNK_TWO');
+    expect(text).toContain('CHUNK_THREE');
+    expect(text).toContain('src/big.ts (lines 1-50)'); // range label rendered
+  });
+
+  it('re-reading the SAME range collapses to latest content', () => {
+    const history: ConversationMessage[] = [
+      ...readRangeTurn('r1', 'src/x.ts', 'RANGE_OLD', 10, 20),
+      ...readRangeTurn('r2', 'src/x.ts', 'RANGE_NEW', 10, 20),
+      { role: 'assistant', content: [{ type: 'text', text: 'final hot turn' }] as MessageContentBlock[] },
+    ];
+    const text = allText(compactTurns(history, 50, 1).compacted);
+    expect(text).toContain('RANGE_NEW');
+    expect(text).not.toContain('RANGE_OLD');
+  });
+
+  it('an edit invalidates ALL ranges of that path', () => {
+    const history: ConversationMessage[] = [
+      ...readRangeTurn('r1', 'src/y.ts', 'Y_CHUNK_A', 1, 40),
+      ...readRangeTurn('r2', 'src/y.ts', 'Y_CHUNK_B', 41, 80),
+      ...editTurn('e1', 'src/y.ts'),
+      { role: 'assistant', content: [{ type: 'text', text: 'final hot turn' }] as MessageContentBlock[] },
+    ];
+    const text = allText(compactTurns(history, 50, 1).compacted);
+    expect(text).not.toContain('Y_CHUNK_A');
+    expect(text).not.toContain('Y_CHUNK_B');
+    expect(text).toContain('[file edited: src/y.ts]');
   });
 });

--- a/packages/ant-cli/tests/tasks/ui/hooks.test.ts
+++ b/packages/ant-cli/tests/tasks/ui/hooks.test.ts
@@ -3,13 +3,14 @@
  *
  * Locks the contract for T6 call-site flips:
  *   - scheduling.preUiBarrier  — true (orchestrator gates ui while feature/setup runs)
+ *   - scheduling.blocksTestgen — true (ui gates test-code so tests target built views)
  *   - conversations.convKey    — `node:execute:ui:<id>`
  *   - registry entry           — `hooksForTaskType('ui')` returns the bundle
  */
 
 import { describe, it, expect } from 'vitest';
 
-import { preUiBarrier } from '../../../src/agents/architect/graph/code/tasks/ui/hooks/scheduling';
+import { preUiBarrier, blocksTestgen } from '../../../src/agents/architect/graph/code/tasks/ui/hooks/scheduling';
 import * as convHook from '../../../src/agents/architect/graph/code/tasks/ui/hooks/conversations';
 import { hooks as uiBundle } from '../../../src/agents/architect/graph/code/tasks/ui';
 import { hooksForTaskType } from '../../../src/agents/architect/graph/code/tasks/_shared/registry';
@@ -53,16 +54,19 @@ describe('tasks/_shared/registry — ui entry', () => {
     expect(uiBundle.decompose).toBeUndefined();
   });
 
-  it('scheduling exposes only the ui consumer flag — no other consumer or producer flags', () => {
+  it('scheduling: ui consumer flag + blocksTestgen producer only', () => {
     expect(uiBundle.scheduling?.preUiBarrier).toBe(true);
     expect(uiBundle.scheduling?.preTestgenBarrier).toBeUndefined();
     expect(uiBundle.scheduling?.preDocBarrier).toBeUndefined();
     expect(uiBundle.scheduling?.preIntegrationBarrier).toBeUndefined();
-    // UI is a barrier sink only — it must NEVER activate barriers for
-    // other task types. Regression guard: if someone adds a producer
-    // flag here it changes orchestrator scheduling semantics silently.
+    // UI gates ONLY testgen — test-code waits until ui work finishes so
+    // generated tests target fully-built views (alongside setup/feature).
+    expect(uiBundle.scheduling?.blocksTestgen).toBe(true);
+    // It must NOT activate any other barrier. Regression guard: adding a
+    // producer flag here changes orchestrator scheduling semantics silently.
+    // (No self-block on ui; doc reaches ui transitively via test-code;
+    // integration is a feature-band concern.)
     expect(uiBundle.scheduling?.blocksUi).toBeUndefined();
-    expect(uiBundle.scheduling?.blocksTestgen).toBeUndefined();
     expect(uiBundle.scheduling?.blocksDoc).toBeUndefined();
     expect(uiBundle.scheduling?.blocksIntegration).toBeUndefined();
   });
@@ -71,6 +75,9 @@ describe('tasks/_shared/registry — ui entry', () => {
 describe('tasks/ui/hooks/scheduling', () => {
   it('preUiBarrier — true', () => {
     expect(preUiBarrier).toBe(true);
+  });
+  it('blocksTestgen — true', () => {
+    expect(blocksTestgen).toBe(true);
   });
 });
 


### PR DESCRIPTION
…de behind ui

#1 — compaction read-loop (grave-bolting-cloud RCA). compactTurns' extractLatestReadContent preserved read content keyed by PATH, keeping only the latest read per file. A large reference file read in multiple line-range chunks then collapsed to its last chunk on compaction, so the model lost the earlier chunks and re-read them — re-bloating history, re-triggering compaction, and looping until the worker subgraph's 200-step LangGraph recursion limit crashed the task (and paused the whole parallel job). This is the same dim-beating-brass loop 33d9acb9 fixed for whole-file reads, recurring for ranged reads. Evidence: the failing ui task oscillated ~95K<->~36K context 10 times across 92 execute calls (259 reads / 0 writes).

- Key preserved reads by (path, range), not path alone, so every distinct chunk survives compaction. A whole-file read is the range=none point of the same key space (reading a file whole twice still dedups to latest), so there is no separate compatibility branch and existing whole-file behaviour is unchanged. An edit/create of a path drops ALL preserved ranges of that path (staleness-safe). Shared core/context infra → fixes plan + execute + design
  + planner at once. No recursion cap / counter / prompt change.

#2 — test-code now waits for ui. Added scheduling.blocksTestgen to the ui bundle so test-code's preTestgenBarrier fires while ui work runs (alongside setup/feature). Tests are generated against fully-built views, not half-rendered components. doc is gated transitively via test-code. No deadlock: ui still flows; test-code waits for ui to drain.

Tests: compactTurns chunked-read preservation + edit-invalidation cases; ui registry test locks blocksTestgen=true with other producer flags undefined. Full suite 4312 passing, tsc clean.

<!--
Thanks for contributing to Ant!
Before opening this PR, please read CONTRIBUTING.md.
-->

## Summary

<!-- One or two sentences describing what this PR changes and why. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] CI / build / tooling

## Affected area

- [ ] `ant-cli` (backend / agents / LangGraph)
- [ ] `ant-ui` (frontend)
- [ ] `ant-shared` (cross-package types)
- [ ] Prompts / templates
- [ ] Docs (`docs/`)
- [ ] CI / build

## Test plan

<!--
How did you verify this works?

- Commands you ran (e.g. `pnpm test:cli`, `pnpm typecheck`).
- Manual scenarios you walked through.
- Screenshots or recordings for UI changes.
-->

## Linked issue

<!-- e.g. Closes #123 -->

## Checklist

- [ ] `pnpm build` succeeds locally (this also runs the tests).
- [ ] `pnpm typecheck` is clean.
- [ ] I added or updated tests when changing behaviour.
- [ ] I updated documentation (`docs/`, README, AGENTS.md) if my change affects users or contributors.
- [ ] No internal hostnames, incident codenames, or personal identifiers in this diff.
- [ ] If I touched prompts, I ran the relevant prompt-policy tests.
- [ ] Commit messages follow Conventional Commits (`feat: ...`, `fix: ...`).
