### PR TITLE
refactor(decompose): unify per-task injection into single `include` SSOT

### DIFF
--- a/docs/internals/14-code-job.md
+++ b/docs/internals/14-code-job.md
@@ -86,11 +86,13 @@ LLM 출력 <techTier>             코드 파싱               mergeTechTier(pres
 │ stack            │───>│ parsed           │───>│ RAC.basis        │
 │ language         │    │   .stack         │    │   .techTier      │
 │ framework        │    │   .language      │    │     .stack       │
-│ packageTiers     │    │   .framework     │    │     .language    │
-└──────────────────┘    │   .packageTiers  │    │     .framework   │
-                        └──────────────────┘    │     .runtime     │
-                                                └──────────────────┘
+│ frontend{ … }    │    │   .framework     │    │     .frontend    │
+│ backend{ … }     │    │   .frontend      │    │     .backend     │
+└──────────────────┘    │   .backend       │    └──────────────────┘
+                        └──────────────────┘
 ```
+
+> fullstack 잡은 `frontend` / `backend` 서브오브젝트로 각 런타임 framework 를 독립 전달한다 (FE/BE 런타임 분리상 framework 가 한 값으로 붕괴하면 안 된다). 단일-스택 잡은 두 서브오브젝트를 생략하고 top-level `framework` 만 쓴다.
 
 | TechTier 필드 | 판별 소스 | 정규화 |
 |---|---|---|
@@ -218,10 +220,10 @@ Plan 단계의 RAG 결과(`PlanCodeContext` — files / filePaths / directoryTre
 
 ## Split Injection
 
-병렬 실행 시 태스크의 `packages` 필드에 따라 필요한 설계 문서만 주입한다:
-- `packages = ['fe']` -> fe-system-design + api-contract
-- `packages = ['be']` -> be-system-design + api-contract
-- `packages = ['fe', 'be']` -> 전체 포함
+병렬 실행 시 태스크의 `include` 필드(단일 주입 SSOT)에 나열된 풀 경로만 선주입한다. `include`는 decompose/revise LLM이 직접 저작하고 `createTaskQueue`가 RAC 교집합으로 검증한다. 예:
+- `include = ['architecture/system/fe-system-main.md']` -> 해당 FE 설계문서만
+- cross-tier 태스크 -> `architecture/system/api-contract-*` 경로를 include 에 추가
+- `include` 미설정 -> 선주입 0; 필요한 doc 은 execute `read_file` 로 on-demand 조회 (RAC 스코프 게이트 통과)
 
 plan 노드는 RAG 결과를 파일 경로 목록만 주입한다. 실제 파일 읽기는 execute `read_file` 도구로 수행한다.
 
@@ -258,17 +260,18 @@ interface ParsedUiDocs {
 
 `ArtifactPipeline`이 태스크별 문서 선택 + 컴팩션을 처리한다:
 
-1. `buildCodeArtifactPool(state)` — 레거시 state 변수(`designDocs`, `specDocs`, `parsedUiDocs`, `sourceDocuments`, `prd`)를 `ResolvedArtifact[]` 풀로 변환
-2. `resolveArtifacts(pool, { taskType, include }, { threshold })` — `task.include` 패턴 또는 taskType 기본 규칙으로 필터링 + 컴팩션
+1. 풀은 RAC 부분집합 — `loadResolvedArtifacts(resolvedAction, featurePath)`가 `refs ∪ context`만 적재한다 (`state.artifacts Post-RAC SSOT`).
+2. `resolveArtifacts(pool, { taskType, include }, { threshold })` — `task.include` 의 path-prefix 매칭으로 필터링 + 컴팩션.
 
-| task.type | 기본 선택 규칙 |
+선택 규칙은 단일 SSOT다 — `task.include` 매칭이 전부이고 taskType 기본 분기는 없다:
+
+| 조건 | 선택 결과 |
 |-----------|---------------|
-| `ui`, `design-system` | `visual/ui/ant/*` (ant UiSource 기준; figma/handoff 는 per-task `artifactPolicy` 가 직접 지정) |
-| `feature`, `setup`, `test-code`, `doc` | `architecture/system/*` + `architecture/spec/*` + `visual/ui/*` + `plan` 전체 |
-| `error` | spec + api-contract (spec 존재 시) |
-| `verification` | 빈 배열 |
+| `taskType === 'verification'` | 빈 배열 (방어적 가드) |
+| `include` 지정 | include path-prefix 에 매칭되는 풀 아티팩트 (role 은 풀 RAC 주석에서 상속) |
+| `include` 미설정/빈 값 | 빈 배열 (taskType 기본 규칙 없음 — 명시적 빈 주입) |
 
-`task.include`가 지정되면 기본 규칙 대신 정확한 path-prefix 매칭이 적용된다. `include`는 decompose LLM이 출력하거나, `packages`/`uiSections` + RAC의 활성 spec ref(`ArtifactPoolView.activeSpecRefFilename()`)에서 자동 유도된다.
+`include`는 decompose/revise LLM이 직접 저작한다 (RAC 검증). UI 경로는 uiSource 게이트 가이드(`visual/ui/ant/spec/<section>` 등), spec-driven 태스크는 활성 spec(`ArtifactPoolView.activeSpecRefFilename()`)을 include 에 포함하도록 프롬프트가 안내한다. 옛 `packages`/`uiSections`/`artifactPolicy` 자동 유도는 제거됐다.
 
 ### Document Authority
 

--- a/docs/testing/prompt-test-spec.md
+++ b/docs/testing/prompt-test-spec.md
@@ -25,7 +25,7 @@ D. Build Pipeline (빌드 파이프라인)
 │                                      Stage 1: 경로 해석 / Stage 2: 렌더 성공 / Stage 3: 내용 주입
 │  artifact-injection-e2e.test.ts ──── 아티팩트 role별 주입 + directive 경로별 주입 정방향 E2E (12 시나리오)
 │                                      + JSON 매트릭스 생성 (__generated__/artifact-injection-matrix.json)
-│  artifact-injection-audit.test.ts ── build() 호출부 artifacts 전달 + decompose artifactPolicy 정적 감사 (7 케이스)
+│  artifact-injection-audit.test.ts ── build() 호출부 artifacts 전달 + decompose include 정적 감사 (단일 주입 SSOT)
 │  prompt-integration.test.ts ──────── ArtifactPipeline, 문서 조립 시나리오
 │  documents-pipeline-audit.test.ts ── 문서 파이프라인 회귀 미러
 │
@@ -181,7 +181,7 @@ G. Non-prompt (비프롬프트)
 | 그룹 | 대상 파일 | 검증 |
 |------|-----------|------|
 | 2-A. build() 호출부 | code/execute/buildMessages, design/docGen/intent/system, design/docGen/intent/spec | `artifacts` 키워드 존재 |
-| 2-B. decompose 노드 | code/decompose/responseParser, design/decompose/uiDesign·systemDesign·spec | `artifactPolicy` 키워드 존재 |
+| 2-B. decompose 노드 | code/decompose/responseParser, design/decompose/uiDesign·systemDesign·spec | `include` 키워드 존재 + `artifactPolicy` 부재 |
 
 ### prompt-integration.test.ts
 
@@ -247,7 +247,7 @@ G. Non-prompt (비프롬프트)
 
 1. action-context.md, directive.md, PromptBuilder 브릿지, build() 호출부 수정
 2. `pnpm test:cli` → artifact-injection-e2e가 12개 시나리오 role별 렌더 검증
-3. artifact-injection-audit가 호출부 artifacts 전달 + decompose artifactPolicy 설정 감사
+3. artifact-injection-audit가 호출부 artifacts 전달 + decompose include 설정(및 artifactPolicy 부재) 감사
 4. `artifact-injection-matrix.json` diff로 주입 경로 변화 추적
 
 ---

--- a/packages/ant-cli/src/agents/architect/graph/code/nodes/decompose/index.ts
+++ b/packages/ant-cli/src/agents/architect/graph/code/nodes/decompose/index.ts
@@ -15,7 +15,7 @@
 import { LLMClient } from "../../../../../../core/ports";
 import { extractLLMInfo } from "../../../../../../core/ports/workflow";
 import { ArchitectGraphState } from "../../state";
-import { BOUNDARY, SUGGESTED_BOUNDARY, resolveTaskTechTiersFromMap, applyExplicitTechTierOverrides, getTechTier, type Boundary, type TechTierConfig, SURFACE_SYSTEM_VARIANTS, SPATIAL_SYSTEM_VARIANTS, getVisualLanguagesWithModes, isTierActive, getEffectiveDomain, getConfigSlots, GAME_ART_CONCEPT_VARIANTS, GAME_ART_PERSPECTIVE_VARIANTS, GAME_GENRE_VARIANTS, coreLoopCandidatesFor, SUPPORTED_GAME_ENGINES } from "@ant/shared";
+import { BOUNDARY, SUGGESTED_BOUNDARY, resolveTaskTechTierFromStack, applyExplicitTechTierOverrides, getTechTier, type Boundary, type TechTierConfig, SURFACE_SYSTEM_VARIANTS, SPATIAL_SYSTEM_VARIANTS, getVisualLanguagesWithModes, isTierActive, getEffectiveDomain, getConfigSlots, GAME_ART_CONCEPT_VARIANTS, GAME_ART_PERSPECTIVE_VARIANTS, GAME_GENRE_VARIANTS, coreLoopCandidatesFor, SUPPORTED_GAME_ENGINES } from "@ant/shared";
 import { JobTimingManager } from "../../../../../common/graph/timing/JobTimingManager";
 import { logErrorHeader } from "../_common/errorHandler";
 import { logPrompt } from "../../../../../../core/utils/promptLogger";
@@ -34,6 +34,7 @@ import { checkSessionRestore, restoreFromSession } from "./sessionManager";
 import { prepareRacInjection } from "./designSelector";
 import { callLLMForDecompose } from "./llmCaller";
 import { parseLLMResponse, parseTaskItemJson, createTaskQueue, logTaskSummary } from "./responseParser";
+import { computeRacScope } from "./racGate";
 import { saveAnalysisForDebug } from "./saveAnalysisText";
 import type { BaseTask, TaskType } from "@ant/shared";
 import {
@@ -328,9 +329,9 @@ export async function decompose(state: ArchitectGraphState): Promise<ArchitectGr
   // See `AGENTS.md` "Post-RAC Template Condition SSOT".
   const hasUi = pool.hasUi();
 
-  // Functional meta — UI section IDs inform the LLM's `uiSections`
-  // task assignment. Full content is NOT embedded here; plan/execute
-  // load sections per task via artifactPolicy.
+  // Functional meta — UI section IDs inform the LLM's per-task `include`
+  // authoring (e.g. `visual/ui/ant/spec/<id>`). Full content is NOT embedded
+  // here; plan/execute select sections per task via `include`.
   //
   // ID = basename — fine for all three UiSource prefixes
   // (`visual/ui/{ant,figma,handoff}/…`).
@@ -659,7 +660,8 @@ export async function decompose(state: ArchitectGraphState): Promise<ArchitectGr
     const type: TaskType = typeof raw.type === 'string' ? raw.type as TaskType : 'feature';
     const priority = typeof raw.priority === 'number' ? raw.priority : 300;
     const description = typeof raw.description === 'string' ? raw.description : '';
-    const packages = Array.isArray(raw.packages) ? raw.packages.filter((p: any) => typeof p === 'string') : undefined;
+    const stack: 'frontend' | 'backend' | undefined =
+      raw.stack === 'frontend' || raw.stack === 'backend' ? raw.stack : undefined;
     const exclusive = typeof raw.exclusive === 'boolean' ? raw.exclusive : undefined;
     const parallelGroup = typeof raw.parallelGroup === 'string' ? raw.parallelGroup : undefined;
     const minimal: BaseTask = {
@@ -668,7 +670,7 @@ export async function decompose(state: ArchitectGraphState): Promise<ArchitectGr
       type,
       priority,
       description,
-      ...(packages && { packages }),
+      ...(stack && { stack }),
       ...(exclusive !== undefined && { exclusive }),
       ...(parallelGroup && { parallelGroup }),
     };
@@ -706,13 +708,8 @@ export async function decompose(state: ArchitectGraphState): Promise<ArchitectGr
       const { ARCHITECT_TOOLS } = await import('../../../../../common/tool/toolSchemas');
       const { handleReadFile, handleListFiles } = await import('../../../../../common/tool/handlers');
       const { CLARIFY_TOOL, handleClarify } = await import('../../../../../common/clarify');
-      const racGate = await import('./racGate');
-      const { decideRacGate } = racGate;
-      type RacScope = (typeof racGate)['decideRacGate'] extends (t: any, s: infer S) => any ? S : never;
-
-      const racScope: RacScope = isExplicitPipeline
-        ? { refs: _racRefs, context: _racContext }
-        : undefined;
+      const { decideRacGate } = await import('./racGate');
+      const racScope = computeRacScope(state.resolvedAction);
 
       // Silent chatStatus — sourceSelector.callLLMWithToolLoop owns
       // the UI emission for every tool call in the loop (one card per
@@ -1146,7 +1143,7 @@ export async function decompose(state: ArchitectGraphState): Promise<ArchitectGr
     activeSpecRefFilename,
     uiSource ?? undefined,
     executionTier,
-    isExplicitPipeline ? 'explicit' : 'infer',
+    computeRacScope(state.resolvedAction),
   );
   logTaskSummary(tasks, referenceRequests);
   
@@ -1162,7 +1159,6 @@ export async function decompose(state: ArchitectGraphState): Promise<ArchitectGr
     );
 
     const inferredConfig: TechTierConfig = { stack };
-    const pkgTiers = parsedTechTier.packageTiers as Record<string, { language?: string; framework?: string; stack: string }> | undefined;
 
     // Phase 1 — gameEngine 5th slot. The LLM emits `"gameEngine"` inside the
     // <techTier> JSON; the parser surfaces it as `parsedTechTier.gameEngine`
@@ -1170,27 +1166,32 @@ export async function decompose(state: ArchitectGraphState): Promise<ArchitectGr
     // in the browser, so engine is meaningful only on the frontend tier).
     const parsedGameEngine = parsedTechTier.gameEngine;
 
-    if (pkgTiers && stack === 'fullstack') {
-      const feEntries = Object.values(pkgTiers).filter(e => e.stack === 'frontend');
-      const beEntries = Object.values(pkgTiers).filter(e => e.stack === 'backend');
-      const feEntry = feEntries[0];
-      const beEntry = beEntries[0];
+    if (stack === 'fullstack') {
+      // Fullstack ⇒ FE and BE are distinct runtime categories, so frameworks
+      // are ALWAYS two independent values read from the stack-keyed `frontend`
+      // / `backend` sub-objects. NEVER fall back to `defaultTier.framework`
+      // for framework — that would unify FE and BE under one framework, which
+      // is incorrect. Language may legitimately be shared, so it keeps the
+      // defaultTier fallback.
+      const feParsed = parsedTechTier.frontend;
+      const beParsed = parsedTechTier.backend;
       inferredConfig.frontend = {
-        language: ((feEntry?.language ?? defaultTier.language) as 'typescript' | 'go') ?? 'typescript',
-        framework: feEntry?.framework ?? defaultTier.framework,
+        language: ((feParsed?.language ?? defaultTier.language) as 'typescript' | 'go') ?? 'typescript',
+        framework: feParsed?.framework ?? undefined,
         stack: 'frontend',
         gameEngine: parsedGameEngine,
       };
       inferredConfig.backend = {
-        language: ((beEntry?.language ?? defaultTier.language) as 'typescript' | 'go') ?? 'typescript',
-        framework: beEntry?.framework ?? defaultTier.framework,
+        language: ((beParsed?.language ?? defaultTier.language) as 'typescript' | 'go') ?? 'typescript',
+        framework: beParsed?.framework ?? undefined,
         stack: 'backend',
       };
     } else {
-      if (stack === 'fullstack' || stack === 'frontend') {
+      // Single-stack / no-stack — fullstack is fully handled above.
+      if (stack === 'frontend') {
         inferredConfig.frontend = { ...defaultTier, stack: 'frontend', gameEngine: parsedGameEngine };
       }
-      if (stack === 'fullstack' || stack === 'backend') {
+      if (stack === 'backend') {
         inferredConfig.backend = { ...defaultTier, stack: 'backend' };
       }
       if (!stack) {
@@ -1231,8 +1232,8 @@ export async function decompose(state: ArchitectGraphState): Promise<ArchitectGr
     if (parsedTechTier.stackReasoning) {
       console.log(`   Reasoning: ${parsedTechTier.stackReasoning}`);
     }
-    if (parsedTechTier.packageTiers) {
-      console.log(`   PackageTiers: ${Object.keys(parsedTechTier.packageTiers).join(', ')}`);
+    if (stack === 'fullstack') {
+      console.log(`   Fullstack frameworks: frontend=${mergedConfig.frontend?.framework || 'none'}, backend=${mergedConfig.backend?.framework || 'none'}`);
     }
     
     if (state.deps?.previewUpdate && state.context) {
@@ -1378,16 +1379,16 @@ export async function decompose(state: ArchitectGraphState): Promise<ArchitectGr
   }
 
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  // STEP 6.7: Assign task-level techTier (packageTiers mapping)
+  // STEP 6.7: Assign task-level techTier (task.stack → config slot)
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   const currentTechTierConfig = state.resolvedAction?.basis?.techTier;
   if (currentTechTierConfig) {
     // Explicit techTier (raw actionMetadata.basis.techTier — never merged with LLM emit)
-    // is the authority signal: preset fields override LLM-emitted packageTiers entries
-    // for the same stack. Mirrors the visualTier / gameArtTier / gameContentTier policy.
+    // is the authority signal: preset fields override LLM-emitted values for the same
+    // stack. Mirrors the visualTier / gameArtTier / gameContentTier policy.
     const explicitTechTier = state.actionMetadata?.basis?.techTier;
     for (const task of taskQueue.getAll()) {
-      const resolved = resolveTaskTechTiersFromMap(task.packages, currentTechTierConfig, parsedTechTier?.packageTiers);
+      const resolved = resolveTaskTechTierFromStack(task.stack, currentTechTierConfig);
       task.techTiers = applyExplicitTechTierOverrides(resolved, explicitTechTier);
     }
     const narrowedCount = taskQueue.getAll().filter(t => {

--- a/packages/ant-cli/src/agents/architect/graph/code/nodes/decompose/racGate.ts
+++ b/packages/ant-cli/src/agents/architect/graph/code/nodes/decompose/racGate.ts
@@ -17,6 +17,7 @@
  * same deny message, same orthogonality contract.
  */
 
+import type { ResolvedActionContext } from '@ant/shared';
 import { normalizeToCodebasePath } from '../../../../../../core/utils/pathNormalizer';
 
 export const RAC_DENY_MESSAGE =
@@ -27,6 +28,28 @@ export const RAC_DENY_MESSAGE =
 export interface RacScope {
   refs: string[];
   context: string[];
+}
+
+/**
+ * Derive the active RAC scope from a resolved action. Pure function shared by
+ * every code-job phase that gates `read_file` / `list_files` (decompose inline
+ * dispatch + the shared code `tool` node serving plan/execute).
+ *
+ * Returns a `RacScope` only for the explicit pipeline (user pinned the RAC):
+ * `source === 'explicit'` AND `hasExplicitFields` AND `refs ∪ context` non-empty.
+ * Infer pipelines return `undefined` → `decideRacGate` allows everything
+ * (the LLM legitimately needs to discover anchors).
+ */
+export function computeRacScope(
+  resolvedAction: ResolvedActionContext | undefined,
+): RacScope | undefined {
+  const refs = resolvedAction?.refs ?? [];
+  const context = resolvedAction?.context ?? [];
+  const isExplicit =
+    resolvedAction?.source === 'explicit'
+    && (resolvedAction?.hasExplicitFields ?? false)
+    && (refs.length + context.length > 0);
+  return isExplicit ? { refs, context } : undefined;
 }
 
 /**

--- a/packages/ant-cli/src/agents/architect/graph/code/nodes/decompose/responseParser.ts
+++ b/packages/ant-cli/src/agents/architect/graph/code/nodes/decompose/responseParser.ts
@@ -17,11 +17,9 @@ import {
   asJsonSyntaxViolation,
 } from '../../../../../../core/utils/llmResponseParser';
 
-import type { PackageTierEntry, TaskType, GameEngine } from '@ant/shared';
+import type { TaskType, GameEngine, TechTier } from '@ant/shared';
 import { SUPPORTED_GAME_ENGINES } from '@ant/shared';
-import { flattenPolicyToInclude } from '../../../../../../core/artifact/ArtifactPipeline';
-
-type ArtifactPolicy = { refs?: string[]; context?: string[] };
+import { isWithinRacWhitelist, type RacScope } from './racGate';
 
 /**
  * Three-Axis SSOT — the SOLE phase site that translates `priority` into a
@@ -52,122 +50,19 @@ export function deriveBandFromPriority(priority: number): TaskBand | undefined {
   return undefined;
 }
 
-/**
- * Pipeline mode discriminator for `deriveArtifactPolicy`.
- *
- *   - `'infer'`   — RAC was inferred (no explicit user selection). The LLM's
- *                   `packages` tag is the canonical signal for which design
- *                   docs to inject; package → `fe-system-X.md` mapping is
- *                   active.
- *   - `'explicit'` — RAC was pinned by the user (`source: 'explicit'` AND
- *                   non-empty `refs ∪ context`). The user-selected files
- *                   are the sole authority; package-based ref synthesis
- *                   is suppressed. `packages` survives only as a tech-tier
- *                   hint consumed by `resolveTaskTechTiersFromMap`.
- *
- * Channel B closure for the `state.artifacts Post-RAC SSOT` (see
- * `AGENTS.md` and the `discovery-tool RAC bypass (2026-04)` regression). Without
- * suppression, a directive job whose RAC excluded `fe-system-main.md`
- * still ended up with that path baked into every `task.artifactPolicy.refs`
- * and `task.include`, which downstream phases then re-fetched from disk.
- */
-export type ArtifactPolicyMode = 'infer' | 'explicit';
-
-/**
- * Derive role-annotated artifact selection policy from legacy task fields.
- * Returns undefined for verification tasks (no docs needed).
- *
- * `activeSpecRefFilename` is the filename of the spec promoted to a
- * development source by the RAC (see `ArtifactPoolView.activeSpecRefFilename`).
- * The decompose LLM does NOT select specs anymore — the choice is fixed
- * upstream by intent + action metadata.
- *
- * `uiSource` selects the interpretation branch for ui/design-system tasks:
- *   - 'ant'     → honour `uiSections` to build a narrow subset of the canonical
- *                 ui-tokens/assets/spec JSON pool.
- *   - 'figma'   → ignore `uiSections`; inject the figma.json reference and
- *                 defer real data to live MCP exploration at execute time.
- *   - 'handoff' → ignore `uiSections` (handoff has no schema); select the
- *                 handoff directory via wildcard. `loadResolvedArtifacts`
- *                 replaces each file's content with a STUB (path + size +
- *                 kind + read_file hint) so the bundle behaves like source
- *                 code: execute/plan read files on demand rather than
- *                 receiving the whole bundle inline.
- * When undefined, fall back to 'ant' semantics for backward compatibility.
- *
- * `mode` — see `ArtifactPolicyMode`. Explicit pipelines suppress
- * package → `fe-system-X.md` ref synthesis. UI/design-system tasks keep
- * their `uiSections` branch in both modes because those paths are already
- * inside the RAC (the user explicitly selected the UI source slot when
- * the intent matrix exposed it).
- */
-export function deriveArtifactPolicy(
-  taskType: TaskType,
-  packages?: string[],
-  uiSections?: string[],
-  activeSpecRefFilename?: string | null,
-  uiSource?: UiSource,
-  mode: ArtifactPolicyMode = 'infer',
-): ArtifactPolicy | undefined {
-  // R1 — phase layer is blind to `task.type`. The predicate helpers below
-  // take a `{ type }` shape so this function (which owns only the type
-  // string, not the full task object) can still dispatch through the
-  // task-bundle SSOT.
-  const taskShape = { type: taskType };
-  if (isVerificationTask(taskShape)) return undefined;
-
-  if (isUiTask(taskShape) || isDesignSystemTask(taskShape)) {
-    const src: UiSource = uiSource ?? 'ant';
-    if (src === 'figma') {
-      return { context: [`${ARTIFACT_PREFIX.UI_FIGMA}figma.json`] };
-    }
-    if (src === 'handoff') {
-      return { context: [`${ARTIFACT_PREFIX.UI_HANDOFF}*`] };
-    }
-    // src === 'ant'
-    const contextPaths: string[] = [];
-    if (uiSections?.length) {
-      contextPaths.push(`${ARTIFACT_PREFIX.UI_ANT}tokens`);
-      for (const sec of uiSections) {
-        if (sec === 'tokens') continue;
-        if (sec === 'assets') contextPaths.push(`${ARTIFACT_PREFIX.UI_ANT}assets`);
-        else contextPaths.push(`${ARTIFACT_PREFIX.UI_ANT_SPEC}${sec}`);
-      }
-    } else {
-      contextPaths.push(`${ARTIFACT_PREFIX.UI_ANT}*`);
-    }
-    return contextPaths.length > 0 ? { context: contextPaths } : undefined;
-  }
-
-  const refPaths: string[] = [];
-  if (activeSpecRefFilename) refPaths.push(`${ARTIFACT_PREFIX.SPEC}${activeSpecRefFilename}`);
-
-  // Channel B closure (`state.artifacts Post-RAC SSOT`): the
-  // `packages → fe-system-X.md` mapping is the legacy infer-mode
-  // mechanism for surfacing design docs to plan/execute. When the user
-  // explicitly pinned the RAC, those paths must come from the user's
-  // refs/context only — synthesizing them from `packages` reintroduces
-  // the `post-RAC pool-leak (2026-04)` / `discovery-tool RAC bypass (2026-04)` leak even though
-  // `state.artifacts` itself is RAC-bounded. `packages` is preserved on
-  // the task for tech-tier resolution only.
-  if (mode === 'infer' && packages?.length) {
-    for (const pkg of packages) {
-      if (pkg.startsWith('fe-')) refPaths.push(`${ARTIFACT_PREFIX.FE_SYSTEM}${pkg.slice(3)}.md`);
-      else if (pkg.startsWith('be-')) refPaths.push(`${ARTIFACT_PREFIX.BE_SYSTEM}${pkg.slice(3)}.md`);
-      else if (pkg === 'shared') refPaths.push(`${ARTIFACT_PREFIX.API_CONTRACT}*`);
-    }
-    if (!packages.includes('shared')) refPaths.push(`${ARTIFACT_PREFIX.API_CONTRACT}*`);
-  }
-
-  return refPaths.length > 0 ? { refs: refPaths } : undefined;
-}
-
 export interface ParsedTechTier {
   stack: string;
   stackReasoning: string;
   language: string;
   framework?: string | null;
-  packageTiers?: Record<string, PackageTierEntry>;
+  /**
+   * Stack-keyed framework sub-objects. For fullstack jobs the LLM emits each
+   * runtime's framework independently here, because FE (browser) and BE (Node)
+   * are distinct runtime categories and their frameworks never collapse to one.
+   * Single-stack jobs omit both.
+   */
+  frontend?: Partial<TechTier>;
+  backend?: Partial<TechTier>;
   /**
    * Phase 1 — game-domain 5th slot. When the LLM emits `"gameEngine": "phaser"`
    * inside the `<techTier>` JSON, the parser surfaces it here so the
@@ -291,7 +186,7 @@ export function parseLLMResponse(rawResponse: string): ParsedDecomposeResponse {
       throw new Error('Invalid response: tasks must be an array');
     }
     
-    // ✅ Extract techTier from <techTier> tag (stack + language + framework + packageTiers)
+    // ✅ Extract techTier from <techTier> tag (stack + language + framework + frontend/backend sub-objects)
     let techTier: ParsedTechTier | undefined;
     const techTierMatch = rawResponse.match(/<techTier>\s*([\s\S]*?)\s*<\/techTier>/);
     
@@ -307,7 +202,8 @@ export function parseLLMResponse(rawResponse: string): ParsedDecomposeResponse {
           stackReasoning: parsed.stackReasoning || '',
           language: normalizeLanguage(parsed.language || 'typescript'),
           framework: normalizeFramework(parsed.framework || null),
-          packageTiers: parsed.packageTiers || undefined,
+          frontend: parsed.frontend || undefined,
+          backend: parsed.backend || undefined,
           gameEngine,
         };
       } catch (error) {
@@ -468,7 +364,7 @@ export function createTaskQueue(
   activeSpecRefFilename: string | null | undefined,
   defaultUiSource: UiSource | undefined,
   executionTier: ExecutionTierId,
-  mode: ArtifactPolicyMode = 'infer',
+  racScope?: RacScope,
 ): {
   taskQueue: TaskQueue<CodeTask>;
   featureTasks: Map<string, CodeTask>;
@@ -590,31 +486,38 @@ export function createTaskQueue(
       ? 'verification' as const
       : (task.type || DEFAULT_TASK_TYPE);
 
-    const uiSections: string[] | undefined = Array.isArray((task as any).uiSections) ? (task as any).uiSections : undefined;
-    const packages: string[] | undefined = Array.isArray((task as any).packages) ? (task as any).packages : undefined;
-
     // Resolve uiSource: explicit task field wins, otherwise inherit the pool-derived
     // default from the decompose node. Only UI-related task types consume this field;
     // everything else drops it. Kept undefined (not written) for non-UI tasks so the
-    // BaseTask.uiSource contract stays clean.
+    // BaseTask.uiSource contract stays clean. uiSource is an interpretation axis
+    // (ui-source-dispatch partial gate), NOT an injection selector — `include`
+    // owns injection.
     const explicitUiSource = typeof (task as any).uiSource === 'string' ? (task as any).uiSource as UiSource : undefined;
     const inheritedUiSource = explicitUiSource ?? defaultUiSource;
     const isUiRelated = isUiTask({ type: resolvedType }) || isDesignSystemTask({ type: resolvedType });
     const uiSource: UiSource | undefined = isUiRelated ? inheritedUiSource : undefined;
 
-    // artifactPolicy: role-annotated selection; include: flat backward-compat projection.
-    //
-    // `mode` threads the RAC-source gate (Channel B closure). When
-    // `mode === 'explicit'` the user pinned refs/context — `packages` is
-    // a tech-tier hint only and MUST NOT auto-synthesize `fe-system-X.md`
-    // refs (`discovery-tool RAC bypass (2026-04)` regression). The LLM may still emit a
-    // bare `include` array; we keep that pass-through but it is ignored
-    // by the explicit pipeline because explicit mode in
-    // `execute/buildMessages` selects from the RAC pool directly via
-    // `state.resolvedAction.{refs,context}` rather than `task.include`.
-    const explicitInclude: string[] | undefined = Array.isArray((task as any).include) ? (task as any).include : undefined;
-    const artifactPolicy = deriveArtifactPolicy(resolvedType, packages, uiSections, activeSpecRefFilename, uiSource, mode);
-    const include = explicitInclude ?? flattenPolicyToInclude(artifactPolicy);
+    // Per-task stack pointer (narrowing). Always single at task level.
+    const rawStack = (task as any).stack;
+    const stack: 'frontend' | 'backend' | undefined =
+      rawStack === 'frontend' || rawStack === 'backend' ? rawStack : undefined;
+
+    // Single injection SSOT — LLM-authored `include`, RAC-validated. When the
+    // RAC is pinned (explicit pipeline → racScope set), out-of-RAC paths are
+    // dropped with a warning. Belt-and-suspenders: the pool is itself a RAC
+    // subset, so `selectArtifacts(pool, {include})` already misses out-of-RAC
+    // paths — this guard surfaces the drift loudly. verification tasks carry
+    // no include (selectArtifacts returns [] for them regardless).
+    const rawInclude: string[] | undefined = Array.isArray((task as any).include) ? (task as any).include : undefined;
+    const include: string[] | undefined = rawInclude
+      ? rawInclude.filter((p: string) => {
+          const ok = isWithinRacWhitelist(p, racScope);
+          if (!ok) {
+            console.warn(`⚠️ [Decompose] Dropped include path outside RAC: "${p}" (task "${task.id || task.name}")`);
+          }
+          return ok;
+        })
+      : undefined;
 
     // Tier-Verification Alignment: Tier 2 Exploratory self-verify flag passthrough.
     //   - Emitted by the decompose LLM at Tier 2 (exactly one task).
@@ -642,10 +545,8 @@ export function createTaskQueue(
       type: resolvedType,
       priority: resolvedPriority,
       description: task.description,
-      uiSections,
-      packages,
       include,
-      artifactPolicy,
+      stack,
       uiSource,
       exclusive: exclusive || undefined,
       parallelGroup,

--- a/packages/ant-cli/src/agents/architect/graph/code/nodes/decompose/validation.ts
+++ b/packages/ant-cli/src/agents/architect/graph/code/nodes/decompose/validation.ts
@@ -1,6 +1,5 @@
 import { CodeTask } from "../../../../types/task";
 import type { TaskType, ResolvedArtifact } from '@ant/shared';
-import { getDesignDocByPackageFromPool } from '../../../../../../core/prompt/builder/ArtifactPipeline';
 import { isErrorTask } from '../../tasks/error';
 import { hooksForTaskType } from '../../tasks/_shared/registry';
 
@@ -115,17 +114,19 @@ export function validateTasks(
   directive: string | undefined,
   artifacts?: ResolvedArtifact[],
 ): void {
-  // Warn about packages referencing non-existent design docs
+  // Warn about include paths that match nothing in the post-RAC pool — the
+  // single injection SSOT is `task.include`, so an include that matches no
+  // artifact silently injects nothing for that path.
   if (artifacts && artifacts.length > 0) {
     for (const t of tasks) {
-      if (!t.packages) continue;
-      for (const pkg of t.packages) {
-        if (pkg === 'shared') continue;
-        const content = getDesignDocByPackageFromPool(pkg, artifacts);
-        if (!content) {
+      if (!t.include?.length) continue;
+      for (const inc of t.include) {
+        const prefix = inc.endsWith('*') ? inc.slice(0, -1) : inc;
+        const matches = artifacts.some(a => a.path === inc || a.path.startsWith(prefix));
+        if (!matches) {
           console.warn(
-            `⚠️  [Decompose Validation] Task "${t.id}" references package "${pkg}" ` +
-            `but no matching design doc found — design doc will not be injected for this tag`
+            `⚠️  [Decompose Validation] Task "${t.id}" include "${inc}" ` +
+            `matches no artifact in the RAC pool — nothing will be injected for it`
           );
         }
       }

--- a/packages/ant-cli/src/agents/architect/graph/code/nodes/execute/buildMessages.ts
+++ b/packages/ant-cli/src/agents/architect/graph/code/nodes/execute/buildMessages.ts
@@ -30,7 +30,7 @@ import { collectResolvedPartials } from "../../../../../../periphery/adapters/pr
 import { ArtifactService } from "../../../../../../infrastructure/workspace/ArtifactService";
 import { detectImageMimeFromBuffer, type AnthropicImageMime } from "../../../../../../core/utils/imageMime";
 import { cleanFileContentFromResponse } from "../../utils/responseCleaners";
-import { selectArtifacts, selectArtifactsWithPolicy, compactArtifacts, ArtifactPoolView } from "../../../../../../core/prompt/builder/ArtifactPipeline";
+import { selectArtifacts, compactArtifacts, ArtifactPoolView } from "../../../../../../core/prompt/builder/ArtifactPipeline";
 import { effectiveTechTier, getTechTier, getRACDocuments, getModelContextWindow, type ResolvedArtifact } from "@ant/shared";
 import { deriveArtifactPolicies } from "../../../../../../core/prompt/builder/ArtifactRoleResolver";
 import { AutoInjectionResolver } from "../../../../../../core/prompt/builder/AutoInjectionResolver";
@@ -298,42 +298,25 @@ export async function buildMessages(state: ArchitectGraphState): Promise<Array<{
   const poolView = new ArtifactPoolView(state.artifacts || []);
   const pool = poolView.all;
 
-  const hasExplicitSelection = state.resolvedAction?.hasExplicitFields
-    && ((state.resolvedAction.refs?.length ?? 0) + (state.resolvedAction.context?.length ?? 0) > 0);
-
+  // Single per-task injection SSOT — `task.include` only. Both explicit and
+  // infer pipelines flow through the SAME narrowing path; the legacy explicit
+  // full-RAC bypass (which injected `refs ∪ context` wholesale and ignored
+  // `task.include`) is removed so per-task narrowing is structurally possible.
+  // Pool doc not pre-injected here is reachable on-demand via RAC-scoped reads
+  // (the code `tool` node gate). `verification` → selectArtifacts returns [].
   let resolvedActionWithDocs = state.resolvedAction;
-  if (hasExplicitSelection) {
-    const explicitPolicy = {
-      refs: state.resolvedAction!.refs || [],
-      context: state.resolvedAction!.context || [],
-    };
-    const selected = selectArtifactsWithPolicy(pool, explicitPolicy);
-    if (selected.length > 0) {
-      const compacted = compactArtifacts(selected, { threshold: 30_000 });
-      resolvedActionWithDocs = {
-        ...(state.resolvedAction!),
-        artifacts: compacted,
-        documents: compacted,
-      };
-      const totalChars = compacted.reduce((s, a) => s + (a.content?.length || 0), 0);
-      console.log(`📄 [Execute] Explicit: ${pool.length} pool → ${compacted.length} selected (${totalChars.toLocaleString()} chars, refs=${JSON.stringify(explicitPolicy.refs)}, context=${JSON.stringify(explicitPolicy.context)})`);
-    }
-  } else {
-    const task = state.currentTask;
-    const selected = task.artifactPolicy
-      ? selectArtifactsWithPolicy(pool, task.artifactPolicy)
-      : selectArtifacts(pool, { taskType: task.type, include: task.include });
-    const inferred = compactArtifacts(selected, { threshold: 30_000 });
+  const task = state.currentTask;
+  const selected = selectArtifacts(pool, { taskType: task.type, include: task.include });
+  const inferred = compactArtifacts(selected, { threshold: 30_000 });
 
-    if (inferred.length > 0) {
-      resolvedActionWithDocs = {
-        ...(state.resolvedAction || { source: 'infer' as const, mode: 'generate' as const, tech: {}, hasExplicitFields: false }),
-        artifacts: inferred,
-        documents: inferred,
-      };
-      const totalChars = inferred.reduce((s, a) => s + (a.content?.length || 0), 0);
-      console.log(`📄 [Execute] Pipeline: ${pool.length} pool → ${inferred.length} selected (${totalChars.toLocaleString()} chars, include=${JSON.stringify(task.include ?? 'default')})`);
-    }
+  if (inferred.length > 0) {
+    resolvedActionWithDocs = {
+      ...(state.resolvedAction || { source: 'infer' as const, mode: 'generate' as const, tech: {}, hasExplicitFields: false }),
+      artifacts: inferred,
+      documents: inferred,
+    };
+    const totalChars = inferred.reduce((s, a) => s + (a.content?.length || 0), 0);
+    console.log(`📄 [Execute] ${pool.length} pool → ${inferred.length} selected (${totalChars.toLocaleString()} chars, include=${JSON.stringify(task.include ?? [])})`);
   }
 
   const { ARTIFACT_PREFIX: AP } = await import('@ant/shared');
@@ -457,12 +440,9 @@ export async function buildMessages(state: ArchitectGraphState): Promise<Array<{
         : (state.directive || ''),
       referenceRequests: state.referenceRequests || [],
       // Gate flag — execute branches on whether UI artifacts are
-      // present in the post-RAC selected pool. Role semantics are
-      // already baked into the selection (`selectArtifactsWithPolicy`
-      // reassigns `role='context'` for ui/design-system tasks; explicit
-      // user selections keep their authored role); the template only
-      // needs presence. See `AGENTS.md`
-      // "Post-RAC Template Condition SSOT".
+      // present in the post-RAC selected pool. Role is inherited from the
+      // pool's RAC annotation (3-axis Authority); the template only needs
+      // presence. See `AGENTS.md` "Post-RAC Template Condition SSOT".
       hasUi: new ArtifactPoolView(getRACDocuments(resolvedActionWithDocs)).hasUi(),
       uiSource: new ArtifactPoolView(getRACDocuments(resolvedActionWithDocs)).uiSource(),
       isSpecDriven: new ArtifactPoolView(state.artifacts || []).activeSpecRefFilename() !== null,
@@ -804,7 +784,7 @@ export async function buildMessages(state: ArchitectGraphState): Promise<Array<{
             artifactPool: pool.length,
             artifactsSelected: getRACDocuments(resolvedActionWithDocs).length,
             include: state.currentTask?.include || undefined,
-            packages: state.currentTask?.packages || undefined,
+            stack: state.currentTask?.stack || undefined,
             planText: state.planText ? `[${state.planText.length} chars]` : undefined,
             detectedMode: state.resolvedAction?.mode,
             taskType: state.currentTask?.type,

--- a/packages/ant-cli/src/agents/architect/graph/code/nodes/plan/llm/prompt.ts
+++ b/packages/ant-cli/src/agents/architect/graph/code/nodes/plan/llm/prompt.ts
@@ -93,25 +93,25 @@ export async function buildPlanPrompt(
   // Spec-driven = a spec artifact is present with role='ref' (RAC-derived).
   const pool = state.artifacts || [];
   const isSpecDriven = new ArtifactPoolView(pool).activeSpecRefFilename() !== null;
-  const hasExplicitDocs = state.resolvedAction?.source === 'explicit'
-    && ((state.resolvedAction?.artifacts?.length ?? state.resolvedAction?.documents?.length ?? 0) > 0);
 
-  let planDocs: ResolvedArtifact[] = [];
+  // Single per-task injection SSOT — `task.include` only. The legacy explicit
+  // full-RAC bypass (which reused `resolvedAction.documents` for explicit
+  // pipelines and skipped per-task narrowing) is removed so both pipelines
+  // narrow identically. Pool doc not pre-injected here is reachable on-demand
+  // via RAC-scoped reads (the code `tool` node gate).
   let resolvedActionWithDocs = state.resolvedAction;
-  if (!hasExplicitDocs) {
-    planDocs = resolveArtifacts(pool,
-      { taskType: task.type, include: task.include },
-      { threshold: 30_000 });
+  const planDocs: ResolvedArtifact[] = resolveArtifacts(pool,
+    { taskType: task.type, include: task.include },
+    { threshold: 30_000 });
 
-    if (planDocs.length > 0) {
-      resolvedActionWithDocs = {
-        ...(state.resolvedAction || { source: 'infer' as const, mode: 'generate' as const, tech: {}, hasExplicitFields: false }),
-        artifacts: planDocs,
-        documents: planDocs,
-      };
-      const totalChars = planDocs.reduce((s, a) => s + (a.content?.length || 0), 0);
-      console.log(`📄 [Plan] Pipeline: ${pool.length} pool → ${planDocs.length} selected (${totalChars.toLocaleString()} chars, include=${JSON.stringify(task.include ?? 'default')})`);
-    }
+  if (planDocs.length > 0) {
+    resolvedActionWithDocs = {
+      ...(state.resolvedAction || { source: 'infer' as const, mode: 'generate' as const, tech: {}, hasExplicitFields: false }),
+      artifacts: planDocs,
+      documents: planDocs,
+    };
+    const totalChars = planDocs.reduce((s, a) => s + (a.content?.length || 0), 0);
+    console.log(`📄 [Plan] ${pool.length} pool → ${planDocs.length} selected (${totalChars.toLocaleString()} chars, include=${JSON.stringify(task.include ?? [])})`);
   }
 
   const taskTechTiers = task.techTiers?.length ? task.techTiers : (getTechTier(state) ? [getTechTier(state)!] : []);

--- a/packages/ant-cli/src/agents/architect/graph/code/nodes/plan/llm/single.ts
+++ b/packages/ant-cli/src/agents/architect/graph/code/nodes/plan/llm/single.ts
@@ -66,7 +66,7 @@ export async function generatePlanText(
             taskDescription: task.description ? `[${task.description.length} chars]` : undefined,
             directive: state.directive ? `[${state.directive.length} chars]` : undefined,
             include: task.include || undefined,
-            packages: task.packages || undefined,
+            stack: task.stack || undefined,
             hasProjectCodeContext: !!codeContext,
             isRetry: !!violationsText,
             // hook-supplied variant variables (verification / error /

--- a/packages/ant-cli/src/agents/architect/graph/code/nodes/revise/index.ts
+++ b/packages/ant-cli/src/agents/architect/graph/code/nodes/revise/index.ts
@@ -154,8 +154,8 @@ export async function revise(state: ArchitectGraphState): Promise<ArchitectGraph
         type: 'setup' | 'feature' | 'design-system' | 'ui' | 'test-code' | 'doc';
         priority: number;
         insertAfter?: string;
-        uiSections?: string[];
-        packages?: string[];
+        include?: string[];
+        stack?: 'frontend' | 'backend';
       }>;
     };
 
@@ -292,8 +292,8 @@ function applyTaskModifications(
       type: 'setup' | 'feature' | 'design-system' | 'ui' | 'test-code' | 'doc';
       priority: number;
       insertAfter?: string;
-      uiSections?: string[];
-      packages?: string[];
+      include?: string[];
+      stack?: 'frontend' | 'backend';
     }>;
   }
 ): ArchitectGraphState {
@@ -328,11 +328,11 @@ function applyTaskModifications(
         description: taskDef.description,
         type: taskDef.type,
         priority: taskDef.priority,
-        ...(taskDef.uiSections && { uiSections: taskDef.uiSections }),
-        ...(taskDef.packages && { packages: taskDef.packages }),
+        ...(taskDef.include?.length && { include: taskDef.include }),
+        ...(taskDef.stack && { stack: taskDef.stack }),
       };
       newTasks.push(newTask);
-      console.log(`   ➕ Added task: "${newTask.name}" (P${newTask.priority}, type=${newTask.type}, packages=${taskDef.packages?.join(',') || 'none'})`);
+      console.log(`   ➕ Added task: "${newTask.name}" (P${newTask.priority}, type=${newTask.type}, stack=${taskDef.stack || 'none'})`);
     }
   }
   

--- a/packages/ant-cli/src/agents/architect/graph/code/nodes/tool/index.ts
+++ b/packages/ant-cli/src/agents/architect/graph/code/nodes/tool/index.ts
@@ -14,6 +14,7 @@ import { buildTaskReminder, updateCommandHistory } from './utils/helpers';
 import { recordServerStarted } from './utils/serverTracking';
 import { createToolNode } from '../../../../../common/tool/createToolNode';
 import { createCodeToolRegistry } from '../../../../../common/tool/presets';
+import { computeRacScope, decideRacGate } from '../decompose/racGate';
 import { createChatStatusReporter } from '../../../../../common/tool/chatStatusAdapter';
 import type { ToolExecutionContext, ToolExecutionEvent } from '../../../../../common/tool/types';
 import { hooksIfActive } from '../../tasks/_shared/registry';
@@ -29,6 +30,21 @@ const toolNodeFn = createToolNode<ArchitectGraphState>({
       name: tc.name,
       args: tc.args,
     }));
+  },
+
+  // RAC-scope gate for plan/execute on-demand file reads — the single
+  // code-job seam serving BOTH phases (they share this `tool` node). Mirrors
+  // the decompose inline gate so the RAC boundary is symmetric: explicit
+  // pipelines may read only inside `refs ∪ context` (plus codebase/, which
+  // `decideRacGate` treats as orthogonal); infer pipelines (racScope=undefined)
+  // allow everything. Only file-access tools carry a single artifact path.
+  // Common handlers stay RAC-orthogonal — the policy lives here, not in them.
+  gateCall(state, call) {
+    if (call.name !== 'read_file' && call.name !== 'list_files') return { allowed: true };
+    const racScope = computeRacScope(state.resolvedAction);
+    if (!racScope) return { allowed: true };
+    const target = ((call.args as any)?.path ?? (call.args as any)?.directory ?? '') as string;
+    return decideRacGate(target, racScope);
   },
 
   buildContext(state): ToolExecutionContext {

--- a/packages/ant-cli/src/agents/architect/graph/code/tasks/_shared/batchSplit/process.ts
+++ b/packages/ant-cli/src/agents/architect/graph/code/tasks/_shared/batchSplit/process.ts
@@ -1,4 +1,5 @@
 import type { TechTier } from '@ant/shared';
+import { ARTIFACT_PREFIX } from '@ant/shared';
 import { ArchitectGraphState, TASK_PRIORITIES, TaskTimingHelper } from '../../../state';
 import { CodeTask } from '../../../../../types/task';
 import { snapshotFromState } from '../../../parallel/TaskWorker';
@@ -375,6 +376,13 @@ export function processDiagnosticBatchSplit(
       // entry by `scheduleFor` — see its comment above for the three
       // dispatch shapes.
       const { parallelGroup, priority } = scheduleFor(i, batch);
+      // `include` carry-over: Path B inherits the parent's manifest; Path A
+      // (verification parent has none) seeds spec+api-contract so fix-applier
+      // sub-tasks keep the context the retired `error` default once supplied.
+      const subInclude: string[] | undefined =
+        effectiveKind === 'requeue-parent'
+          ? [ARTIFACT_PREFIX.SPEC, ARTIFACT_PREFIX.API_CONTRACT]
+          : nextTask.include;
       const subTask: CodeTask = {
         id: `${subType}-batch-${Date.now()}-${Math.random().toString(36).substr(2, 5)}`,
         name: batch.name,
@@ -385,6 +393,10 @@ export function processDiagnosticBatchSplit(
         exclusive: hasFileOverlap,
         parallelGroup,
         batchSplitCount: newBatchSplitCount,
+        // `stack` is carried over verbatim from the parent in BOTH paths
+        // (like `band`) so per-task tech-tier narrowing survives the split.
+        ...(nextTask.stack ? { stack: nextTask.stack } : {}),
+        ...(subInclude?.length ? { include: subInclude } : {}),
         ...(subType === 'feature' ? { band: parentBand } : {}),
       } as CodeTask;
       if (taskPolicy?.populateRemediationMode !== false) {

--- a/packages/ant-cli/src/agents/architect/graph/code/tasks/ui/index.ts
+++ b/packages/ant-cli/src/agents/architect/graph/code/tasks/ui/index.ts
@@ -18,8 +18,8 @@
  * Intentionally absent:
  *   - plan.buildPrompt / extraTemplateVars — UI flows through the
  *     shared `jobs/code/nodes/plan/base` template and the generic
- *     artifact-resolution pipeline. `uiSections` scoping is applied
- *     upstream during decompose (drives `task.include` + `artifactPolicy`),
+ *     artifact-resolution pipeline. UI scoping is applied upstream during
+ *     decompose (the LLM authors `task.include` with the UI pool paths),
  *     so no ui-specific plan variant template or template-var override
  *     is required. There is no `plan/variants/ui/` template and no
  *     planGeneration.ts branch to port.
@@ -28,8 +28,8 @@
  *     transitively via test-code; integration is a feature-band concern).
  *
  * Phase-layer `task.type === 'ui'` residuals were resolved in T6b-κ:
- *   - `nodes/decompose/responseParser.ts deriveArtifactPolicy` — the
- *     ui||design-system design-context guard now dispatches through
+ *   - `nodes/decompose/responseParser.ts` task building — the
+ *     ui||design-system guard dispatches through
  *     `isUiTask` / `isDesignSystemTask` instead of literal comparison.
  *   - `nodes/execute/tools.ts isFrontendTask` — the OR chain
  *     now calls `isUiTask` / `isFeatureTask` / `isDesignSystemTask`.

--- a/packages/ant-cli/src/agents/architect/graph/design/nodes/decompose/gameArtDesignDecompose.ts
+++ b/packages/ant-cli/src/agents/architect/graph/design/nodes/decompose/gameArtDesignDecompose.ts
@@ -229,9 +229,6 @@ export async function decomposeGameArtDesign(
       const includePrefixes = isFigmaMode
         ? [ARTIFACT_PREFIX.SOURCES, ARTIFACT_PREFIX.GAME_ART_ANT, ARTIFACT_PREFIX.UI_ANT, ARTIFACT_PREFIX.UI_FIGMA]
         : [ARTIFACT_PREFIX.SOURCES, ARTIFACT_PREFIX.GAME_ART_ANT, ARTIFACT_PREFIX.UI_ANT];
-      const contextPrefixes = isFigmaMode
-        ? [ARTIFACT_PREFIX.GAME_ART_ANT, ARTIFACT_PREFIX.UI_ANT, ARTIFACT_PREFIX.UI_FIGMA]
-        : [ARTIFACT_PREFIX.GAME_ART_ANT, ARTIFACT_PREFIX.UI_ANT];
 
       taskQueue.push({
         id: task.id,
@@ -240,11 +237,8 @@ export async function decomposeGameArtDesign(
         priority: task.priority,
         description: task.description,
         sourceFiles: sf.length > 0 ? sf : undefined,
+        // Single injection SSOT — `include`; role inherited from RAC pool.
         include: includePrefixes,
-        artifactPolicy: {
-          refs: [ARTIFACT_PREFIX.SOURCES],
-          context: contextPrefixes,
-        },
         completed: false,
         targetFile: task.targetFile,
         parallelGroup,

--- a/packages/ant-cli/src/agents/architect/graph/design/nodes/decompose/specDecompose.ts
+++ b/packages/ant-cli/src/agents/architect/graph/design/nodes/decompose/specDecompose.ts
@@ -263,9 +263,6 @@ export async function decomposeSpec(
       totalSections: tasks.length,
       sectionScope: chapter.scope,
       include: [ARTIFACT_PREFIX.SOURCES, ARTIFACT_PREFIX.API_CONTRACT],
-      artifactPolicy: {
-        refs: [ARTIFACT_PREFIX.SOURCES, ARTIFACT_PREFIX.API_CONTRACT],
-      },
       parallelGroup,
       completed: false,
     };

--- a/packages/ant-cli/src/agents/architect/graph/design/nodes/decompose/systemDesignDecompose.ts
+++ b/packages/ant-cli/src/agents/architect/graph/design/nodes/decompose/systemDesignDecompose.ts
@@ -20,7 +20,7 @@ import { parseLLMJsonResponse } from "../../utils/jsonResponseParser";
 import { safeLogPrompt } from "../../utils/promptLog";
 import { saveDecomposeCheckpoint } from "../../session/checkpoint";
 import { resolveDesignTargetFiles } from "../../../../../../core/types/detection";
-import { BOUNDARY, type Mode, buildTechTier, type Stack, type TechTierConfig, resolveTaskTechTiersFromMap, applyExplicitTechTierOverrides, type PackageTierEntry } from "@ant/shared";
+import { BOUNDARY, type Mode, buildTechTier, type Stack, type TechTier, type TechTierConfig, resolveTaskTechTierFromStack, applyExplicitTechTierOverrides } from "@ant/shared";
 import { parseExecutionTierTag, coerceExecutionTier, recordUserTurnMeta, ExecutionTierId } from "../../../../../../core/executionTier";
 import { assignedNotInCatalog, resolveCatalogEntry } from "./catalogLookup";
 
@@ -61,8 +61,18 @@ export interface SystemDesignResponse {
    */
   consumedApis?: string[];
   targetFiles: string[];
-  techTier?: { stack: string; language: string; framework?: string };
-  packageTiers?: Record<string, PackageTierEntry>;
+  /**
+   * Job-level tech stack. For fullstack the `frontend` / `backend` sub-objects
+   * carry each runtime's framework independently — FE (browser) and BE (server)
+   * are distinct runtime categories whose frameworks never collapse to one.
+   */
+  techTier?: {
+    stack: string;
+    language: string;
+    framework?: string;
+    frontend?: Partial<TechTier>;
+    backend?: Partial<TechTier>;
+  };
   tasks: Array<{
     id: string;
     name: string;
@@ -446,15 +456,15 @@ function generateMinimumTasks(targetFiles: string[]): SystemDesignResponse['task
 // ============================================
 
 /**
- * Convert a design targetFile to a normalized tag using Code Job `packages` convention.
- * e.g. "be-system-auth.md" → "be-auth", "api-contract-main.md" → "be-main"
+ * Derive a design task's per-task `stack` pointer from its targetFile prefix.
+ * `fe-system-*.md` → frontend; `be-system-*.md` / `api-contract-*.md` → backend.
+ * `stack` is the single per-task tech-tier narrowing pointer (it replaced the
+ * old package-name tag convention).
  */
-function targetFileToTag(targetFile: string): string | undefined {
-  const match = targetFile.match(/^(be-system|fe-system|api-contract)-(.+)\.md$/);
-  if (!match) return undefined;
-  const [, prefix, name] = match;
-  const tier = prefix === 'fe-system' ? 'fe' : 'be';
-  return `${tier}-${name}`;
+function targetFileToStack(targetFile: string): 'frontend' | 'backend' | undefined {
+  if (/^fe-system-/.test(targetFile)) return 'frontend';
+  if (/^(be-system|api-contract)-/.test(targetFile)) return 'backend';
+  return undefined;
 }
 
 // ============================================
@@ -484,9 +494,9 @@ function buildTaskQueue(
 
   // consumedApis-derived api-contract files capture an EXTERNAL contract
   // — they are not authored by this project and must NOT contribute to
-  // this project's techTier resolution. The `targetFileToTag` mapping
-  // (`api-contract-{s}.md → be-{s}`) would otherwise inject a phantom
-  // backend tier hint into `resolveTaskTechTiersFromMap`.
+  // this project's techTier resolution. The `targetFileToStack` mapping
+  // (`api-contract-{s}.md → backend`) would otherwise inject a phantom
+  // backend tier hint via `resolveTaskTechTierFromStack`.
   const consumerApiContractFiles = new Set(
     (response.consumedApis ?? []).map(c => `api-contract-${c}.md`)
   );
@@ -495,16 +505,15 @@ function buildTaskQueue(
     if (!response.targetFiles.includes(taskData.targetFile)) {
       taskData.targetFile = response.targetFiles[0];
     }
-    
+
     const exclusive = typeof taskData.exclusive === 'boolean' ? taskData.exclusive : undefined;
     const parallelGroup = !exclusive && typeof taskData.parallelGroup === 'string'
       ? taskData.parallelGroup
       : undefined;
-    
+
     const isConsumerContract = consumerApiContractFiles.has(taskData.targetFile);
-    const tag = isConsumerContract ? undefined : targetFileToTag(taskData.targetFile);
-    const packages = tag ? [tag] : undefined;
-    const resolvedTiers = resolveTaskTechTiersFromMap(packages, basisTechTierConfig, response.packageTiers);
+    const stack = isConsumerContract ? undefined : targetFileToStack(taskData.targetFile);
+    const resolvedTiers = resolveTaskTechTierFromStack(stack, basisTechTierConfig);
     const taskTechTiers = applyExplicitTechTierOverrides(resolvedTiers, explicitTechTier);
 
     taskQueue.push({
@@ -517,12 +526,10 @@ function buildTaskQueue(
       targetService: taskData.targetService,
       assignedSections: taskData.assignedSections,
       sourceFiles: Array.isArray((taskData as any).sourceFiles) ? (taskData as any).sourceFiles : undefined,
+      // Single injection SSOT — design tasks read upstream plan sources.
       include: [ARTIFACT_PREFIX.SOURCES],
-      artifactPolicy: {
-        refs: [ARTIFACT_PREFIX.SOURCES],
-      },
       isLastTaskForDocument: lastTaskIdPerFile.has(taskData.id),
-      packages,
+      stack,
       techTiers: taskTechTiers,
       exclusive: exclusive || undefined,
       parallelGroup,
@@ -538,12 +545,12 @@ function buildTaskQueue(
     }
   }
 
-  if (response.packageTiers && Object.keys(response.packageTiers).length > 0) {
+  {
     const tierSummary = taskQueue.getAll()
       .filter(t => t.techTiers?.length)
       .map(t => `${t.id}→${t.techTiers!.map(tier => `${tier.language}${tier.framework ? `/${tier.framework}` : ''}`).join('+')}`)
       .join(', ');
-    console.log(`🔧 [Decompose] TechTiers resolved: ${tierSummary || 'none'}`);
+    if (tierSummary) console.log(`🔧 [Decompose] TechTiers resolved: ${tierSummary}`);
   }
   
   return taskQueue;
@@ -774,7 +781,7 @@ export async function decomposeSystemDesign(
         `Re-emit the response strictly in the contract from the original prompt:\n` +
         `  1. Meta tags first, one per line, JSON-encoded body\n` +
         `     (\`<executionTier>\`, \`<documentType>\`, \`<services>\`, \`<fePackages>\`,\n` +
-        `      \`<consumedApis>\`, \`<techTier>\`, \`<packageTiers>\`, \`<targetFiles>\`).\n` +
+        `      \`<consumedApis>\`, \`<techTier>\`, \`<targetFiles>\`).\n` +
         `  2. Then a \`<tasks>\` block with one \`<task>{json}</task>\` per task.\n` +
         `NO markdown fences. NO \`<decompose>\` wrapper. Output the contract only — no other prose.`
       },
@@ -858,15 +865,34 @@ export async function decomposeSystemDesign(
     : buildTechTier(undefined, detectedEnv);
   console.log(`✅ TechTier: stack=${graphTechTier.stack || detectedEnv}, language=${graphTechTier.language}, framework=${graphTechTier.framework || 'none'}`);
 
-  // Sync to RAC basis.techTier (TechTierConfig) so getTechTier(state) returns it
+  // Sync to RAC basis.techTier (TechTierConfig) so getTechTier(state) returns it.
+  // For fullstack, FE and BE frameworks are distinct runtime categories: read
+  // each from the stack-keyed `response.{frontend,backend}` sub-object so they
+  // do NOT collapse to the single `graphTechTier.framework` (FE/BE unification
+  // is incorrect). Language may legitimately be shared, so it keeps the
+  // graphTechTier fallback.
   const tierKey = graphTechTier.stack === 'fullstack' ? undefined : graphTechTier.stack;
+  const isFullstack = graphTechTier.stack === 'fullstack';
   const basisTechTierConfig: TechTierConfig = {
     stack: graphTechTier.stack,
-    ...(tierKey === 'frontend' || graphTechTier.stack === 'fullstack'
+    ...(tierKey === 'frontend'
       ? { frontend: { ...graphTechTier, stack: 'frontend' as const } } : {}),
-    ...(tierKey === 'backend' || graphTechTier.stack === 'fullstack'
+    ...(tierKey === 'backend'
       ? { backend: { ...graphTechTier, stack: 'backend' as const } } : {}),
-    ...(!tierKey && graphTechTier.stack !== 'fullstack'
+    ...(isFullstack
+      ? {
+          frontend: {
+            ...graphTechTier,
+            framework: response.techTier?.frontend?.framework ?? undefined,
+            stack: 'frontend' as const,
+          },
+          backend: {
+            ...graphTechTier,
+            framework: response.techTier?.backend?.framework ?? undefined,
+            stack: 'backend' as const,
+          },
+        } : {}),
+    ...(!tierKey && !isFullstack
       ? { frontend: graphTechTier } : {}),
   };
   state.resolvedAction = {
@@ -889,7 +915,8 @@ export async function decomposeSystemDesign(
       injectedVariables: {
         documentType: response.documentType,
         services: response.services || [],
-        packageTiers: response.packageTiers || {},
+        frontend: response.techTier?.frontend || undefined,
+        backend: response.techTier?.backend || undefined,
         targetFiles: response.targetFiles,
         taskCount: response.tasks.length,
         tasks: response.tasks.map(t => ({ id: t.id, name: t.name, targetFile: t.targetFile, priority: t.priority }))

--- a/packages/ant-cli/src/agents/architect/graph/design/nodes/decompose/uiDesignDecompose.ts
+++ b/packages/ant-cli/src/agents/architect/graph/design/nodes/decompose/uiDesignDecompose.ts
@@ -214,15 +214,12 @@ export async function decomposeUiDesign(
       }
 
       // In figma mode, include the canonical figma workfile reference
-      // (visual/ui/figma/figma.json) as context so UI design tasks
-      // can read it via the role-based artifact pool instead of an ad-hoc
-      // prompt injection.
+      // (visual/ui/figma/figma.json) so UI design tasks can read it via the
+      // artifact pool. Single injection SSOT — `include`; role is inherited
+      // from the pool's RAC annotation.
       const includePrefixes = isFigmaMode
         ? [ARTIFACT_PREFIX.SOURCES, ARTIFACT_PREFIX.UI_ANT, ARTIFACT_PREFIX.UI_FIGMA]
         : [ARTIFACT_PREFIX.SOURCES, ARTIFACT_PREFIX.UI_ANT];
-      const contextPrefixes = isFigmaMode
-        ? [ARTIFACT_PREFIX.UI_ANT, ARTIFACT_PREFIX.UI_FIGMA]
-        : [ARTIFACT_PREFIX.UI_ANT];
 
       taskQueue.push({
         id: task.id,
@@ -232,10 +229,6 @@ export async function decomposeUiDesign(
         description: task.description,
         sourceFiles: sf.length > 0 ? sf : undefined,
         include: includePrefixes,
-        artifactPolicy: {
-          refs: [ARTIFACT_PREFIX.SOURCES],
-          context: contextPrefixes,
-        },
         completed: false,
         targetFile: task.targetFile,
         parallelGroup,

--- a/packages/ant-cli/src/agents/architect/graph/design/nodes/docGen/intent/spec.ts
+++ b/packages/ant-cli/src/agents/architect/graph/design/nodes/docGen/intent/spec.ts
@@ -21,7 +21,7 @@ import { logPrompt } from '../../../../../../../core/utils/promptLogger';
 import type { PromptBuildConfig } from '../../../../../../../core/prompt/builder/PromptBuildConfig';
 import { buildCacheableBlocks } from '../../../../../../../core/prompt/builder/CacheBlockMapper';
 import { composeMessages } from '../../../../../../../core/utils/messageComposer';
-import { selectArtifacts, selectArtifactsWithPolicy, ArtifactPoolView } from '../../../../../../../core/prompt/builder/ArtifactPipeline';
+import { selectArtifacts, ArtifactPoolView } from '../../../../../../../core/prompt/builder/ArtifactPipeline';
 import { TEMPLATE_PATHS } from '../../../../../../../core/prompt/builder/templatePaths';
 import { buildSelfCheckTrailingMessage } from './selfCheck';
 
@@ -109,13 +109,13 @@ export async function buildSpecMessages(state: DesignGraphState): Promise<Array<
 
   const title = task?.name?.replace(/^Spec: .+ — /, 'Spec: ').replace('Spec: ', '') || 'Feature';
 
-  // Artifact selection via artifactPolicy (role-aware) or include (flat)
+  // Single injection SSOT — `task.include` (LLM-authored), SOURCES fallback.
   const currentTask = state.currentTask as DesignTask | undefined;
   const taskSourceFiles = currentTask?.sourceFiles;
 
-  let selectedArtifacts = currentTask?.artifactPolicy
-    ? selectArtifactsWithPolicy(state.artifacts || [], currentTask.artifactPolicy)
-    : selectArtifacts(state.artifacts || [], { include: currentTask?.include || [ARTIFACT_PREFIX.SOURCES] });
+  let selectedArtifacts = selectArtifacts(state.artifacts || [], {
+    include: currentTask?.include?.length ? currentTask.include : [ARTIFACT_PREFIX.SOURCES],
+  });
 
   if (taskSourceFiles?.length) {
     const planPrefix = `${ARTIFACT_PREFIX.SOURCES}/`;

--- a/packages/ant-cli/src/agents/architect/graph/design/nodes/docGen/intent/ui.ts
+++ b/packages/ant-cli/src/agents/architect/graph/design/nodes/docGen/intent/ui.ts
@@ -19,7 +19,7 @@ import { DesignTask } from '../../../../../types/task';
 import type { FigmaNodeSummary } from '@ant/shared';
 import { designDirOf, ARTIFACT_PREFIX, isFigmaPipeline, isFigmaDataPopulated } from '@ant/shared';
 import { composeMessages } from '../../../../../../../core/utils/messageComposer';
-import { selectArtifacts, selectArtifactsWithPolicy } from '../../../../../../../core/prompt/builder/ArtifactPipeline';
+import { selectArtifacts } from '../../../../../../../core/prompt/builder/ArtifactPipeline';
 import { TEMPLATE_PATHS } from '../../../../../../../core/prompt/builder/templatePaths';
 import { extractLastSectionKey } from '../../../_shared/anchor';
 
@@ -88,9 +88,12 @@ export async function buildUiDesignMessages(state: DesignGraphState): Promise<Ar
 
   const taskInclude = (task as DesignTask | undefined)?.include;
   const designTask = task as DesignTask | undefined;
-  let selectedDocs = designTask?.artifactPolicy
-    ? selectArtifactsWithPolicy(state.artifacts || [], designTask.artifactPolicy)
-    : selectArtifacts(state.artifacts || [], { include: [ARTIFACT_PREFIX.SOURCES] });
+  // Single injection SSOT — `task.include` (LLM-authored), falling back to
+  // SOURCES so a task without an authored manifest still sees its upstream
+  // plan docs. Role is inherited from the pool's RAC annotation.
+  let selectedDocs = selectArtifacts(state.artifacts || [], {
+    include: designTask?.include?.length ? designTask.include : [ARTIFACT_PREFIX.SOURCES],
+  });
   if (taskSourceFiles?.length) {
     selectedDocs = selectedDocs.filter(a =>
       taskSourceFiles.some(f => a.path.endsWith('/' + f)),

--- a/packages/ant-cli/src/agents/architect/graph/design/nodes/plan/prompt.ts
+++ b/packages/ant-cli/src/agents/architect/graph/design/nodes/plan/prompt.ts
@@ -19,7 +19,6 @@ import { buildCacheableBlocks } from '../../../../../../core/prompt/builder/Cach
 import { ARTIFACT_PREFIX } from '@ant/shared';
 import {
   selectArtifacts,
-  selectArtifactsWithPolicy,
 } from '../../../../../../core/prompt/builder/ArtifactPipeline';
 
 export interface BuildDesignPlanPromptResult {
@@ -41,9 +40,10 @@ export async function buildPlanPromptBlocks(
   // Artifact selection — mirrors `design/nodes/docGen/intent/spec.ts`.
   const taskAny = task as any;
   const taskSourceFiles: string[] | undefined = taskAny?.sourceFiles;
-  let selectedArtifacts = taskAny?.artifactPolicy
-    ? selectArtifactsWithPolicy(state.artifacts || [], taskAny.artifactPolicy)
-    : selectArtifacts(state.artifacts || [], { include: taskAny?.include || [ARTIFACT_PREFIX.SOURCES] });
+  // Single injection SSOT — `task.include` (LLM-authored), SOURCES fallback.
+  let selectedArtifacts = selectArtifacts(state.artifacts || [], {
+    include: taskAny?.include?.length ? taskAny.include : [ARTIFACT_PREFIX.SOURCES],
+  });
 
   if (taskSourceFiles?.length) {
     const planPrefix = `${ARTIFACT_PREFIX.SOURCES}/`;

--- a/packages/ant-cli/src/agents/architect/graph/design/utils/jsonResponseParser.ts
+++ b/packages/ant-cli/src/agents/architect/graph/design/utils/jsonResponseParser.ts
@@ -46,8 +46,9 @@ import {
  * Each sub-decompose variant uses a different subset:
  *   - ui / game-art       : `targetFiles`, `strategy`
  *   - system-design       : `documentType`, `services`, `fePackages`,
- *                           `consumedApis`, `techTier`, `packageTiers`,
- *                           `targetFiles`, `references`
+ *                           `consumedApis`, `techTier` (carries `frontend`/
+ *                           `backend` framework sub-objects), `targetFiles`,
+ *                           `references`
  *   - spec (inline prompt): `slug`, `title`
  *
  * Adding a new meta tag here is the only change needed to surface it on
@@ -59,7 +60,6 @@ const META_TAG_NAMES = [
   'fePackages',
   'consumedApis',
   'techTier',
-  'packageTiers',
   'documentType',
   'strategy',
   'slug',

--- a/packages/ant-cli/src/agents/architect/types/task.ts
+++ b/packages/ant-cli/src/agents/architect/types/task.ts
@@ -93,8 +93,9 @@ export interface DesignTaskResumeState extends BaseTaskResumeState {}
  */
 interface CodeTaskCommon {
   /**
-   * Per-task technology tiers resolved from decompose's packageTiers map.
-   * Array preserves per-package stack info (e.g., [frontend/ts, backend/go]).
+   * Per-task technology tier(s), resolved from the task's `stack` pointer via
+   * `resolveTaskTechTierFromStack(stack, basis.techTier)`. Single-element at
+   * task level (a task targets exactly one runtime tier).
    */
   techTiers?: TechTier[];
   /**
@@ -121,12 +122,6 @@ interface CodeTaskCommon {
    * branch its "Minimal changes" rule between patch / upstream / refactor.
    */
   remediationMode?: 'patch' | 'upstream' | 'refactor';
-  /**
-   * UI sections required for this task (set by decompose LLM). Used for
-   * split injection — only specified sections are loaded into prompt.
-   * Meaningful only for `ui` / `design-system` variants.
-   */
-  uiSections?: string[];
   /**
    * Per-task resume state (exists only when interrupted during parallel
    * execution). Contains the worker's execution context at the time of
@@ -260,13 +255,12 @@ export type DesignTask = (DocTask | ExplainTask) & {
   sectionScope?: string;           // Description of what this section covers
 
   /**
-   * Per-task technology tiers resolved from decompose's packageTiers map.
+   * Per-task technology tier(s), resolved at buildTaskQueue time from the
+   * task's `stack` pointer (derived from targetFile prefix) via
+   * `resolveTaskTechTierFromStack(stack, basisTechTierConfig)`:
+   * - be-system-auth.md / api-contract-*.md → stack 'backend' → [config.backend]
+   * - fe-system-main.md                     → stack 'frontend' → [config.frontend]
    * Used by PromptResolver to deterministically select framework augmentations.
-   * Array preserves per-package stack info (e.g., [frontend/ts, backend/go]).
-   *
-   * Resolved at buildTaskQueue time via targetFile → tag → packageTiers lookup:
-   * - be-system-auth.md → packages: ["be-auth"] → packageTiers["be-auth"]
-   * - fe-system-main.md → packages: ["fe-main"] → packageTiers["fe-main"]
    */
   techTiers?: TechTier[];
 

--- a/packages/ant-cli/src/agents/common/tool/createToolNode.ts
+++ b/packages/ant-cli/src/agents/common/tool/createToolNode.ts
@@ -36,6 +36,13 @@ export interface ToolNodeConfig<TState> {
   /** Build ToolExecutionContext from state. */
   buildContext(state: TState): ToolExecutionContext;
 
+  /**
+   * Optional per-call gate. When provided, each pending call is checked before
+   * dispatch; a denied call yields an error tool_result instead of executing.
+   * RAC-agnostic at this layer — the code tool node binds an RAC-scope policy.
+   */
+  gateCall?(state: TState, call: ToolCall): { allowed: true } | { allowed: false; error: string };
+
   /** Pre-configured ToolRegistry (from presets + runtime registrations) */
   registry: ToolRegistry;
 
@@ -129,6 +136,7 @@ export function createToolNode<TState>(
 
     const batchResult = await orchestrator.executeBatch(ctx, {
       calls,
+      gateCall: config.gateCall ? (call) => config.gateCall!(state, call) : undefined,
       cache: config.getCache?.(state),
       workflowUpdate: config.getWorkflowUpdate?.(state),
       httpJobId: config.getHttpJobId?.(state),

--- a/packages/ant-cli/src/agents/common/tool/orchestrator.ts
+++ b/packages/ant-cli/src/agents/common/tool/orchestrator.ts
@@ -49,6 +49,14 @@ export interface OrchestratorBatchOptions {
   recursionLimit?: number;
   figmaContext?: FigmaContext;
   uiCardAnimationDelay?: number;
+  /**
+   * Optional per-call gate, evaluated before cache lookup and handler
+   * dispatch. When it denies a call, the orchestrator emits an error
+   * tool_result for that call (preserving tool_use/tool_result pairing) and
+   * skips execution. RAC-agnostic by design — the caller supplies whatever
+   * policy it wants (the code tool node binds an RAC-scope check here).
+   */
+  gateCall?(call: ToolCall): { allowed: true } | { allowed: false; error: string };
 }
 
 // Display names come from TOOL_DISPLAY_NAMES in toolCatalog.ts (single source of truth)
@@ -92,6 +100,23 @@ export class ToolOrchestrator {
     for (const tc of calls) {
       const { id, name, args } = tc;
       console.log(`🔧 [Tool] ${name}`);
+
+      // Per-call gate (RAC-agnostic). Denied calls get an error tool_result so
+      // the tool_use/tool_result pairing the LLM expects stays intact.
+      if (opts.gateCall) {
+        const gate = opts.gateCall(tc);
+        if (!gate.allowed) {
+          console.warn(`🚫 [Tool] ${name} blocked: ${gate.error}`);
+          events.push({
+            toolCallId: id,
+            toolName: name,
+            args,
+            result: { content: `Error: ${gate.error}`, error: gate.error },
+            cached: false,
+          });
+          continue;
+        }
+      }
 
       // Cache check
       if (this.config.cacheEnabled && this.config.cacheableTools?.has(name) && cache) {

--- a/packages/ant-cli/src/core/artifact/ArtifactPipeline.ts
+++ b/packages/ant-cli/src/core/artifact/ArtifactPipeline.ts
@@ -11,7 +11,6 @@
  *
  * Pool extraction helpers (Phase 2):
  *   flattenDesignArtifacts — name→content map from system-design artifacts
- *   getDesignDocByPackageFromPool — lookup by package tag
  *   extractFirstDesign — first system-design artifact content
  *   hasSourceArtifact / getSourceContent — source/prd artifact access
  *
@@ -107,12 +106,18 @@ function matchesInclude(artifactPath: string, patterns: string[]): boolean {
 }
 
 /**
- * Filter candidate artifacts by policy.
+ * Filter candidate artifacts by policy — single per-task injection SSOT.
  *
  * Priority:
- * 1. `taskType: 'verification'` → always empty (no docs needed)
- * 2. `include` present → exact path-prefix match
- * 3. taskType-based default rules (backward-compatible fallback)
+ * 1. `taskType: 'verification'` → always empty (defensive; verification tasks
+ *    carry no `include`).
+ * 2. `include` present → path-prefix / glob match.
+ * 3. No `include` → empty (explicit `[]`, NOT a taskType-based default). The
+ *    legacy taskType default switch was removed — every task's injection is
+ *    now governed solely by its authored `include`.
+ *
+ * Role is inherited from the pool's RAC annotation (3-axis Authority: RAC owns
+ * role), so there is no separate role-aware selection path.
  */
 export function selectArtifacts(
   candidates: ResolvedArtifact[],
@@ -124,73 +129,7 @@ export function selectArtifacts(
     return candidates.filter(a => matchesInclude(a.path, policy.include!));
   }
 
-  // taskType-based defaults (backward compat when include is absent)
-  switch (policy.taskType) {
-    case 'error':
-      if (candidates.some(a => a.path.startsWith(ARTIFACT_PREFIX.SPEC))) {
-        return candidates.filter(
-          a => a.path.startsWith(ARTIFACT_PREFIX.SPEC) ||
-               a.path.startsWith(ARTIFACT_PREFIX.API_CONTRACT),
-        );
-      }
-      return [];
-
-    case 'ui':
-    case 'design-system':
-      return candidates.filter(a => isUiArtifactPath(a.path));
-
-    default:
-      return candidates.filter(
-        a =>
-          a.path.startsWith(ARTIFACT_PREFIX.SYSTEM_DESIGN) ||
-          a.path.startsWith(ARTIFACT_PREFIX.SPEC) ||
-          isUiArtifactPath(a.path) ||
-          isGameArtArtifactPath(a.path) ||
-          a.path.startsWith(ARTIFACT_PREFIX.SOURCES),
-      );
-  }
-}
-
-/**
- * Select artifacts with explicit role assignment from policy.
- * Refs patterns are matched first; context patterns skip already-seen paths.
- */
-export function selectArtifactsWithPolicy(
-  candidates: ResolvedArtifact[],
-  policy: { refs?: string[]; context?: string[] },
-): ResolvedArtifact[] {
-  const result: ResolvedArtifact[] = [];
-  const seen = new Set<string>();
-
-  for (const pattern of policy.refs ?? []) {
-    for (const a of candidates) {
-      if (!seen.has(a.path) && matchesInclude(a.path, [pattern])) {
-        result.push({ ...a, role: 'ref' });
-        seen.add(a.path);
-      }
-    }
-  }
-  for (const pattern of policy.context ?? []) {
-    for (const a of candidates) {
-      if (!seen.has(a.path) && matchesInclude(a.path, [pattern])) {
-        result.push({ ...a, role: 'context' });
-        seen.add(a.path);
-      }
-    }
-  }
-  return result;
-}
-
-/**
- * Flatten an artifactPolicy into a simple include string[].
- * Used for backward-compat when only path prefixes (no roles) are needed.
- */
-export function flattenPolicyToInclude(
-  policy?: { refs?: string[]; context?: string[] },
-): string[] | undefined {
-  if (!policy) return undefined;
-  const all = [...(policy.refs || []), ...(policy.context || [])];
-  return all.length > 0 ? all : undefined;
+  return [];
 }
 
 // ────────────────────────────────────────────────────────────────
@@ -415,22 +354,6 @@ export class ArtifactPoolView {
     return map;
   }
 
-  /**
-   * Look up design document by package tag.
-   * `fe-{name}` → `fe-system-{name}.md`, `be-{name}` → `be-system-{name}.md`.
-   */
-  getDesignDocByPackage(pkg: string): string | undefined {
-    let prefix: string;
-    if (pkg.startsWith('fe-')) {
-      prefix = `${ARTIFACT_PREFIX.FE_SYSTEM}${pkg.slice(3)}`;
-    } else if (pkg.startsWith('be-')) {
-      prefix = `${ARTIFACT_PREFIX.BE_SYSTEM}${pkg.slice(3)}`;
-    } else {
-      return undefined;
-    }
-    return this.pool.find(a => a.path === prefix || a.path === `${prefix}.md`)?.content;
-  }
-
   /** First system-design artifact content (for display/logging). */
   firstDesignContent(): string | undefined {
     return this.pool.find(a => a.path.startsWith(ARTIFACT_PREFIX.SYSTEM_DESIGN))?.content;
@@ -521,9 +444,6 @@ export function flattenDesignArtifacts(artifacts: ResolvedArtifact[]): Record<st
   return new ArtifactPoolView(artifacts).flattenSystemDesigns();
 }
 
-export function getDesignDocByPackageFromPool(pkg: string, artifacts: ResolvedArtifact[]): string | undefined {
-  return new ArtifactPoolView(artifacts).getDesignDocByPackage(pkg);
-}
 
 // ────────────────────────────────────────────────────────────────
 // Design Job Pool Utilities (Phase 3: cross-job unification)

--- a/packages/ant-cli/src/core/prompt/templates/jobs/code/nodes/decompose/variants/default/base.md
+++ b/packages/ant-cli/src/core/prompt/templates/jobs/code/nodes/decompose/variants/default/base.md
@@ -69,9 +69,9 @@ validator.
 {{/if}}
 
 {{#if uiArtifactPaths.length}}
-## UI Document Sections (available for `uiSections` task assignment)
+## UI sections available for `include` (ant source)
 
-Use these IDs when populating `uiSections` on `"ui"` and `"design-system"` tasks.
+These section IDs are available for `"ui"` / `"design-system"` tasks. See "UI injection via `include`" in the rules for how to form each `visual/ui/ant/...` path.
 
 {{#each uiArtifactPaths}}
 - `{{this.id}}` ({{this.role}})
@@ -113,7 +113,7 @@ Observe the following in order:
 3. **Directive and PRD** — only when design documents are absent
 {{/if}}
 
-Explicit values from `resolvedAction.basis.techTier` are authoritative — preserve them as-is in your `<techTier>` output and in any per-package `packageTiers` entries that target the same stack. Infer only the slots that are not pinned by the explicit basis.
+Explicit values from `resolvedAction.basis.techTier` are authoritative — preserve them as-is in your `<techTier>` output, including the `frontend` / `backend` sub-objects that target the same stack. Infer only the slots that are not pinned by the explicit basis.
 
 Output the tech tier in `<techTier>` tags before `<tasks>`:
 
@@ -124,16 +124,13 @@ Output the tech tier in `<techTier>` tags before `<tasks>`:
   "language": "typescript" | "javascript" | "python" | "go" | "rust" | "java",
   "framework": "react" | "vue" | "nextjs" | "express" | "fastapi" | "gin" | ... (or null){{#if gameEngineCandidates}},
   "gameEngine": {{{gameEngineCandidates}}}{{/if}},
-  "packageTiers": {
-    "fe-main": { "language": "typescript", "framework": "nextjs", "stack": "frontend" },
-    "be-api": { "language": "go", "framework": "gin", "stack": "backend" }
-  }
+  "frontend": { "language": "typescript", "framework": "nextjs" },
+  "backend": { "language": "go", "framework": "gin" }
 }
 </techTier>
 
-- `packageTiers` is REQUIRED when `stack` is `"fullstack"` and packages use different languages/frameworks.
-- `packageTiers` is OPTIONAL otherwise (omit when all packages share the same stack).
-- Each key is a package tag (e.g. `fe-main`, `be-auth`, `be-order`).
+- `frontend` / `backend` sub-objects are REQUIRED when `stack` is `"fullstack"` — FE (browser) and BE (server) are distinct runtime categories whose frameworks never collapse to one.
+- Omit both sub-objects for single-stack jobs (the top-level `language` / `framework` is the sole tier).
 {{#if gameEngineCandidates}}
 - `gameEngine` is the game-domain 5th slot. Pick exactly one of the candidates above. The engine layers on top of the framework — `react+phaser` is the canonical Phase 2 combination (React hosts the page, Phaser owns the canvas).
 {{/if}}

--- a/packages/ant-cli/src/core/prompt/templates/jobs/code/nodes/decompose/variants/default/design-doc-guide.md
+++ b/packages/ant-cli/src/core/prompt/templates/jobs/code/nodes/decompose/variants/default/design-doc-guide.md
@@ -51,18 +51,18 @@
 | `api-contract-*` + single `be-system-main.md` | Contract-First | FE + BE packages |
 | `api-contract-*` + multiple `be-system-*.md` | MSA-Contract-First | Package per service |
 
-**Principle**: Each service boundary maps to one package. Each service task references ONLY its own design document via the `packages` field.
+**Principle**: Each service boundary maps to one package. Each service task references ONLY its own design document via the `include` field (that boundary's design-doc path).
 
 **Constraint**: Do NOT mix service implementations in a single task. Each service task targets a single `be-system-{service}.md` scope.
 
-**Constraint**: All tasks that involve cross-tier integration reference `api-contract-*` for interface contracts (this is automatic via the `packages` tag — api-contract is always injected).
+**Constraint**: All tasks that involve cross-tier integration MUST add the `api-contract-*` path to their `include` for interface contracts.
 
 ⚠️ **Blind spot**: When multiple services share a database or message queue, they APPEAR coupled but MUST still be separate tasks with separate packages. Cross-service coordination belongs in a shared foundation task.
 
 ════════════════════════════════════════════════════════════════════════════════
 
 **Critical Rules:**
-- ✅ Every task must reference design doc via `packages` field
+- ✅ Every task must reference its design doc via the `include` field (the design-doc path)
 - ✅ Follow architecture decisions from the design documents
 - ❌ Don't invent architecture not described in design documents
 - ❌ Task scope is bounded by the Development Source (see Scope Determination)

--- a/packages/ant-cli/src/core/prompt/templates/jobs/code/nodes/decompose/variants/default/rules.md
+++ b/packages/ant-cli/src/core/prompt/templates/jobs/code/nodes/decompose/variants/default/rules.md
@@ -64,7 +64,8 @@ Lower-tier preference applies ONLY between these three when genuine unit-count a
 - `name`: human-readable summary of what to explain
 - `type`: `"explain"`
 - `priority`: `200`
-- `packages`: one tier tag covering the area of the codebase to explain (e.g., `fe-main`, `be-main`, or `shared`)
+- `stack`: the tier whose code is being explained (`frontend` / `backend`; omit on single-stack jobs)
+- `include`: the design-doc / spec path(s) that ground the explanation (omit if none apply)
 - `exclusive`: `true`
 - `selfVerifyOnDone`: `false` (explain does not write code, no gates to run)
 - `description`: the full explanation scope derived from the directive
@@ -74,7 +75,8 @@ Lower-tier preference applies ONLY between these three when genuine unit-count a
 - `name`: human-readable task name
 - `type`: the appropriate type (`"error"` for fixes of broken behavior, `"feature"` for new capability, `"ui"` for visual implementation, `"setup"` only for new-project infrastructure)
 - `priority`: per the Task Schema priority band for the chosen type
-- `packages`: relevant package tag(s)
+- `stack`: the runtime tier this task targets (`frontend` / `backend`; omit on single-stack jobs)
+- `include`: the design-doc / spec / api-contract / UI path(s) this task needs (omit if the directive + on-demand reads suffice)
 - `exclusive`: `true` (single-task breakdown is trivially exclusive)
 - `selfVerifyOnDone`: `true` (REQUIRED — signals that the task runs an automatic two-cycle apply→verify lifecycle; after the apply phase emits `<done>`, the runtime transitions the same task into verify-mode and runs install/typecheck/build/test gates against the verification template)
 - `description`: full scope of the unit of work
@@ -84,7 +86,8 @@ Lower-tier preference applies ONLY between these three when genuine unit-count a
 - `name`: human-readable summary of what to explain
 - `type`: `"explain"`
 - `priority`: `200`
-- `packages`: one tier tag covering the area of the codebase to explain (e.g., `fe-main`, `be-main`, or `shared`)
+- `stack`: the tier whose code is being explained (`frontend` / `backend`; omit on single-stack jobs)
+- `include`: the design-doc / spec path(s) that ground the explanation (omit if none apply)
 - `exclusive`: `true`
 - `description`: the full explanation scope derived from the directive
 
@@ -209,8 +212,8 @@ tasks one-by-one as they stream in. The body of each `<task>` is a single JSON o
 following the schema below:
 
 <tasks>
-<task>{"id": "kebab-case-id", "name": "Human-readable task name", "type": "setup", "priority": 100, "packages": ["<tier>-<name>"], "exclusive": true, "description": "What to do"}</task>
-<task>{"id": "another-task", "name": "Another Task", "type": "feature", "priority": 300, "packages": ["<tier>-<name>"], "parallelGroup": "scope-id", "description": "What to do"}</task>
+<task>{"id": "kebab-case-id", "name": "Human-readable task name", "type": "setup", "priority": 100, "stack": "frontend", "include": ["<pool-path>"], "exclusive": true, "description": "What to do"}</task>
+<task>{"id": "another-task", "name": "Another Task", "type": "feature", "priority": 300, "stack": "backend", "include": ["<pool-path>"], "parallelGroup": "scope-id", "description": "What to do"}</task>
 </tasks>
 
 **Field reference:**
@@ -225,10 +228,10 @@ following the schema below:
 {{else}}
 | `priority` | Yes | 100–189: setup, 200–299: feature or design-system (shared foundation / design-system token infra from ui-docs or visualTier policy), 300–599: feature, 600–649: feature (integration), 650–699: ui, 700: test-code, 800: doc, 900–980: error, 1000: verification |
 {{/if}}
-| `packages` | Yes | Which design documents to inject (see Package Tags below) |
+| `include` | Conditional | Artifact pool path(s) to pre-inject for this task (see Injection Manifest below). Omit when the directive + on-demand reads suffice |
+| `stack` | When fullstack | `"frontend"` or `"backend"` — which runtime tier this task targets (see Task Stack below). REQUIRED on fullstack jobs; omit on single-stack |
 | `exclusive` | Conditional | `true` if task must run alone. Determined by `type` and structural role — never by task name or description |
 | `parallelGroup` | Conditional | Group ID for serialization. Tasks with different IDs can run in parallel. Mutually exclusive with `exclusive` |
-| `uiSections` | When type is 'ui' or 'design-system' | Array of UI doc section IDs to inject (see specification for available sections) |
 | `selfVerifyOnDone` | Tier 2 only | `true` when the task should run install/typecheck/build/test gates as part of its lifecycle (Tier 2 Exploratory, single unit of work). The runtime transitions the task into a verify cycle automatically after the apply phase emits `<done>`. Omit or `false` at Tier 3/4 (the dedicated verification task governs gates). |
 | `description` | Yes | Scope boundary + design doc section reference |
 
@@ -284,17 +287,17 @@ CRITICAL:
 {{#if hasUi}}
 {{#if (eq uiSource 'ant')}}
 **Constraint**: ant canonical UI documents exist — create `"design-system"` task(s):
-- Priority 200 (`parallelGroup: "design-system"`): token-to-CSS infrastructure. `uiSections: ["tokens"]`.
-- Priority 201+ (`parallelGroup: "design-system"`): ONLY if framework-level wiring or shared component library is needed. `uiSections: ["tokens", "<component-section>"]`.
+- Priority 200 (`parallelGroup: "design-system"`): token-to-CSS infrastructure. `include: ["visual/ui/ant/tokens"]`.
+- Priority 201+ (`parallelGroup: "design-system"`): ONLY if framework-level wiring or shared component library is needed. `include: ["visual/ui/ant/tokens", "visual/ui/ant/spec/<component-section>"]`.
 {{/if}}
 {{#if (eq uiSource 'figma')}}
 **Constraint**: figma workfile reference is selected — create `"design-system"` task(s) that will consume the workfile via MCP at execute time:
-- Priority 200 (`parallelGroup: "design-system"`): token-to-CSS infrastructure. Do NOT set `uiSections` (Figma has no section schema). The execute stage will call `figma_get_variable_defs` to extract tokens.
+- Priority 200 (`parallelGroup: "design-system"`): token-to-CSS infrastructure. `include: ["visual/ui/figma/figma.json"]` (Figma has no section schema). The execute stage will call `figma_get_variable_defs` to extract tokens.
 - Priority 201+ (`parallelGroup: "design-system"`): ONLY if framework-level wiring or shared component library is needed. The execute stage observes frames via `figma_get_design_context`.
 {{/if}}
 {{#if (eq uiSource 'handoff')}}
 **Constraint**: a handoff bundle is selected — create `"design-system"` task(s) that will observe the bundle:
-- Priority 200 (`parallelGroup: "design-system"`): token-to-CSS infrastructure derived from whatever the handoff files explicitly show. Do NOT set `uiSections` (handoff has no schema).
+- Priority 200 (`parallelGroup: "design-system"`): token-to-CSS infrastructure derived from whatever the handoff files explicitly show. `include: ["visual/ui/handoff/"]` (handoff has no schema).
 - Priority 201+ (`parallelGroup: "design-system"`): ONLY if framework-level wiring or shared component library is needed. Component **design patterns** (structure, layout hierarchy, micro-interactions) MUST be derived from observations of the handoff; the **implementation** is authored in the target codebase's framework and conventions at execute time. Do NOT plan tasks whose deliverable is a verbatim copy of a handoff code file.
 
 **ui task grouping**: If the stub manifest carries multiple code-shaped entries (e.g. several `.jsx` / `.html` / framework-component files), decompose ALSO emits `"ui"` task(s) alongside the design-system task. Grouping signals (observe the manifest shape; do not read file contents at this phase):
@@ -308,7 +311,7 @@ The design-system task handles token / theme infrastructure; ui tasks handle com
 Do NOT embed token setup in setup or ui tasks.
 {{else}}
 {{#if visualTierActive}}
-**Constraint**: No ui-docs but visualTier policy is active — create ONE `"design-system"` task (priority 200, `parallelGroup: "design-system"`) for token infrastructure derived from visualTier policies. No `uiSections` field (no ui-docs to inject). Do NOT create 201+ tasks — those require ui-spec.
+**Constraint**: No ui-docs but visualTier policy is active — create ONE `"design-system"` task (priority 200, `parallelGroup: "design-system"`) for token infrastructure derived from visualTier policies. No `include` field (no ui-docs to inject). Do NOT create 201+ tasks — those require ui-spec.
 {{else}}
 **Constraint**: Neither ui-docs nor visualTier policy is active — do NOT create `"design-system"` tasks. Priority 200–299 tasks are `"feature"` only.
 {{/if}}
@@ -378,7 +381,7 @@ Do NOT embed token setup in setup or ui tasks.
 
 ⚠️ **Blind spot**: Same `parallelGroup` = serialized (cannot run simultaneously). Distinct `parallelGroup` = parallel. Per-package test-code parent tasks modify independent directories — they MUST have different group IDs.
 
-**Constraint**: Each per-package test-code parent task MUST specify its target package in the `packages` field. The description states the package scope — the executor observes actual code within that scope to determine test targets.
+**Constraint**: Each per-package test-code parent task MUST state its target package scope in the `description` (and isolate it with a distinct `parallelGroup` per package). The executor observes actual code within that scope to determine test targets.
 
 **Constraint**: Do NOT create a single test-code task that spans all packages in a multi-package project.
 
@@ -438,7 +441,7 @@ Do NOT embed token setup in setup or ui tasks.
 
 **Constraint**: Description MUST state whether this is "new project documentation" or "update existing documentation for [scope of changes]". Package-level descriptions MUST identify the target package scope.
 
-**Constraint**: `packages` field of each doc task should cover the tier(s) that task documents. Root doc uses all relevant tiers. Package doc uses only its package's tier tag.
+**Constraint**: Each doc task sets `stack` to the tier it documents (omit for a project-wide root doc spanning both tiers on a single-stack job). The `description` states the package/tier scope it covers.
 
 ---
 
@@ -477,69 +480,64 @@ the full path so the executor can copy it directly into the install command.
 
 ---
 
-## UI Sections (split injection)
+## UI injection via `include` (split injection)
 
-When `type` is `"ui"` or `"design-system"`, add `"uiSections": [...]` to specify which UI doc sections are needed.
+When `type` is `"ui"` or `"design-system"`, set `include` to the UI pool path(s) the task needs — the single injection SSOT also governs UI (no separate section field).
 
 {{#if hasUi}}
 {{#if (eq uiSource 'ant')}}
-- `"design-system"` (priority 200): `"uiSections": ["tokens"]`
-- `"design-system"` (priority 201+): `"uiSections": ["tokens", "<component-section>"]`
-- `"ui"` tasks: `"uiSections": ["tokens", "<component-section>"]`
-  If omitted, ALL UI docs are injected (not recommended for large docs).
+- `"design-system"` (priority 200): `"include": ["visual/ui/ant/tokens"]`
+- `"design-system"` (priority 201+): `"include": ["visual/ui/ant/tokens", "visual/ui/ant/spec/<component-section>"]`
+- `"ui"` tasks: `"include": ["visual/ui/ant/tokens", "visual/ui/ant/spec/<component-section>"]`
+  Each `visual/ui/ant/spec/<section>` entry pulls exactly that spec section; omitting the spec path injects only what is listed.
 {{/if}}
 {{#if (eq uiSource 'figma')}}
-- `uiSections` is NOT used for the figma UI source — Figma has no section schema. Tasks receive the figma.json reference; the execute stage calls MCP tools to extract data.
+- figma UI source has no section schema — `include` the figma reference (`visual/ui/figma/figma.json`); the execute stage calls MCP tools to extract data.
 {{/if}}
 {{#if (eq uiSource 'handoff')}}
-- `uiSections` is NOT used for the handoff UI source — handoff has no schema. Tasks receive a STUB manifest of the handoff bundle (path + size + kind per file); the execute stage picks up text contents via `read_file` on demand and references binaries by path only.
+- handoff UI source has no schema — `include` the handoff bundle (`visual/ui/handoff/`); tasks receive a STUB manifest (path + size + kind per file), and the execute stage picks up text contents via `read_file` on demand and references binaries by path only.
 {{/if}}
 {{else}}
-- `"design-system"` tasks: `uiSections` is NOT applicable (no UI source selected).
-- `"ui"` tasks: `uiSections` is NOT applicable (no UI source selected).
+- `"design-system"` / `"ui"` tasks: no UI source selected — omit UI `include` paths (tokens, when present, derive from visualTier policy).
 {{/if}}
 
 ---
 
-## Package Tags (Tech-Tier Hint{{#unless isExplicitPipeline}} + Split Design Doc Injection{{/unless}})
+## Injection Manifest (`include`) + Task Stack (`stack`)
 
-**Constraint**: Every task MUST have `"packages": [...]` so the system can map each task to its tech-tier (language/framework) entry.
+Two orthogonal per-task fields. `include` decides WHICH documents the task sees; `stack` decides WHICH runtime tier (language / framework) the task targets. They never overlap in responsibility.
+
+### `include` — the single per-task injection SSOT
+
+**Principle**: Observe the artifact paths available in `## Provided Documents` above. Declare in `include` the path(s) whose content THIS task needs pre-injected into its plan/execute prompt. Only what you list is injected; anything else the task reads on demand via `read_file`.
+
+**Authoring principles** (declare paths, never invent files that are not in the pool):
+- A task implementing against a system-design boundary includes that boundary's design-doc path.
+- A cross-tier task (one that must honor an API contract shared between tiers) includes the api-contract path.
+- A spec-driven task includes the active spec path.
+- A task that needs no pre-injected document (the directive + on-demand reads suffice) omits `include` or sets it to `[]`.
+- `include` entries are path prefixes — a directory prefix selects every artifact beneath it; an exact path selects one file.
+
+**Constraint**: `include` paths MUST be drawn from the artifact pool shown above. A path outside the pool injects nothing (and, when the RAC is pinned, is rejected).
 
 {{#if isExplicitPipeline}}
-**Constraint — explicit RAC active**: The user has pinned the input documents in `## Provided Documents` above. Treat that selection as the COMPLETE authority for this turn. Do NOT cite, infer, open, or list any file outside the user's `refs ∪ context`. `packages` is a tech-tier hint ONLY in this mode — design / system / API-contract documents are NOT auto-injected by package tag, and the `read_file` / `list_files` tools refuse paths outside the RAC selection.
-
-**How to choose `packages`:**
-- Task touches frontend code -> `fe-main` (or `fe-{pkg}` for monorepo)
-- Task touches backend code -> `be-main` (or `be-{svc}` for MSA)
-- Task touches shared/common code -> `shared`
-- Task touches both tiers -> combine relevant `{tier}-{name}` tags
-
-`packages` decides per-task language/framework when the workspace declares per-package tiers. It does NOT decide which documents the plan/execute phases see — that is fixed by the RAC.
-{{else}}
-**Tag mapping:**
-
-| Tag | Maps To | Description |
-|-----|---------|-------------|
-| `fe-main` | `fe-system-main.md` | Single frontend |
-| `fe-{pkg}` | `fe-system-{pkg}.md` | Multi-package frontend |
-| `be-main` | `be-system-main.md` | Single backend |
-| `be-{svc}` | `be-system-{svc}.md` | MSA service |
-| `shared` | api-contract-main.md only | Shared/utility (types, DTOs, configs) |
-
-**Principle**: Tags always follow `{tier}-{name}` pattern. Single-package projects use `main` as the name.
-
-- `api-contract-main.md` is ALWAYS injected when any package is specified.
-- `shared` tag: only `api-contract-main.md` is injected (no system design doc).
-
-**How to choose:**
-- Task touches frontend code -> `fe-main` (or `fe-{pkg}` for monorepo)
-- Task touches backend code -> `be-main` (or `be-{svc}` for MSA)
-- Task touches shared/common code -> `shared`
-- Task touches both tiers -> combine relevant `{tier}-{name}` tags
-- Root workspace setup -> all tier tags in the project, combined with `"shared"`
-
-⚠️ **Blind spot**: `shared` alone injects ONLY api-contract-main.md — no system design documents. Root setup and shared foundation tasks MUST combine all relevant tier tags. Without tier-specific system design documents, the plan phase cannot observe tech stack versions or infrastructure requirements.
+**Constraint — explicit RAC active**: The user pinned the input documents in `## Provided Documents`. Treat that selection as the COMPLETE authority for this turn. Do NOT cite, infer, open, or list any file outside the user's `refs ∪ context`; `include` MUST stay within that selection, and the `read_file` / `list_files` tools refuse paths outside it.
 {{/if}}
+
+### UI / design-system tasks — `include` by UiSource
+
+When a `ui` / `design-system` task draws from a UI source, choose `include` paths by the active source:
+- **handoff** source → include the handoff bundle path (no schema; the task observes the files on demand).
+- **figma** source → include the figma reference path; real data is fetched live at execute time.
+- **ant** source → include the UI tokens path, plus the specific spec-section paths this task renders.
+
+### `stack` — per-task tech-tier pointer
+
+**Principle**: `stack` selects which runtime tier's language/framework this task targets. It is always a single value at task level.
+- Task touches frontend (browser) runtime code → `"stack": "frontend"`.
+- Task touches backend (server) runtime code → `"stack": "backend"`.
+
+**Constraint**: On a fullstack job, EVERY task MUST set `stack` (frontend and backend are distinct runtime categories — the system cannot infer which one a task targets). On a single-stack job, `stack` may be omitted (the sole tier applies).
 
 ---
 
@@ -632,11 +630,11 @@ When `type` is `"ui"` or `"design-system"`, add `"uiSections": [...]` to specify
 
 **Constraint**: When the observation above identifies cross-boundary atomic coordination needs, the coordination contract is shared infrastructure — the foundation task MUST define it. Without this contract, feature tasks bypass shared interfaces and independently implement coordination logic, causing architectural inconsistency.
 
-**Constraint**: The `packages` field MUST include all tier tags that parallel feature tasks span{{#unless isExplicitPipeline}}, combined with `"shared"`. `"shared"` alone provides only API contract — system design documents are required for the plan phase to identify infrastructure symbols. Always combine the relevant `{tier}-{name}` tags with `"shared"`{{/unless}}.
+**Constraint**: Set the foundation task's `stack` to the tier whose symbols it establishes.{{#unless isExplicitPipeline}} Its `include` MUST list the system-design path(s) for the tier(s) the parallel feature tasks span PLUS the api-contract path — the api-contract alone provides only the cross-tier contract, while the system-design documents are what let the plan phase identify infrastructure symbols.{{/unless}}
 
 **Constraint**: Feature tasks that depend on shared foundation symbols MUST NOT redefine them. They import and use what the shared foundation task established.
 
-⚠️ **Blind spot**: Domain types are easily identified as shared, but response DTOs (enriched types that combine entity data with joined fields) and infrastructure symbols (middleware types, error/response helpers, context extractors) are EASILY LEFT to individual feature tasks — causing feature tasks to MODIFY shared files or create duplicate types. Cross-boundary coordination contracts (how atomic operations compose multiple persistence interfaces) are ESPECIALLY EASY TO OMIT — the foundation defines individual persistence interfaces but not how they compose atomically, forcing feature tasks to bypass those interfaces entirely.{{#unless isExplicitPipeline}} Additionally, if `packages` is set to `["shared"]` alone, the plan phase receives NO system design documents and cannot identify infrastructure patterns. Always combine tier tags with `"shared"`.{{/unless}}
+⚠️ **Blind spot**: Domain types are easily identified as shared, but response DTOs (enriched types that combine entity data with joined fields) and infrastructure symbols (middleware types, error/response helpers, context extractors) are EASILY LEFT to individual feature tasks — causing feature tasks to MODIFY shared files or create duplicate types. Cross-boundary coordination contracts (how atomic operations compose multiple persistence interfaces) are ESPECIALLY EASY TO OMIT — the foundation defines individual persistence interfaces but not how they compose atomically, forcing feature tasks to bypass those interfaces entirely.{{#unless isExplicitPipeline}} Additionally, if `include` carries only the api-contract path, the plan phase receives NO system design documents and cannot identify infrastructure patterns. Always include the relevant system-design path(s) alongside the api-contract.{{/unless}}
 
 ⚠️ **Blind spot — external integration boundaries**: Cross-cutting integration boundaries (SDK clients, wallet/payment providers, auth libraries, third-party API clients) are EASILY LEFT to individual feature tasks because each feature's description tends to phrase the integration as a feature concern (e.g. "navbar shows wallet connect button" and "checkout uses wallet for payment" both implicitly require a wallet adapter). Each feature then independently constructs its own copy of the adapter in a different directory, producing dead code and a split source of truth for the same integration. When {{#if isExplicitPipeline}}the user-pinned reference materials (see `## Provided Documents`){{else}}the design document{{/if}} names an external SDK / provider / API client that 2+ features touch, the adapter for that integration MUST be a shared foundation Implementations sub-task — even if no feature task description mentions the adapter explicitly.
 

--- a/packages/ant-cli/src/core/prompt/templates/jobs/code/nodes/decompose/variants/default/techTier-rules.md
+++ b/packages/ant-cli/src/core/prompt/templates/jobs/code/nodes/decompose/variants/default/techTier-rules.md
@@ -104,17 +104,22 @@ This default applies ONLY when all design documents are absent.
 
 **Framework**: If no framework is mentioned or implied, set `framework: null`.
 
-### packageTiers (Fullstack / Monorepo)
+### Fullstack frameworks (`frontend` / `backend` sub-objects)
 
-**Principle**: When `stack` is `"fullstack"` and packages use different languages or frameworks,
-provide a `packageTiers` map so each task inherits the correct technology context.
+**Principle**: When `stack` is `"fullstack"`, the frontend (browser) and backend (server)
+are distinct runtime categories whose frameworks NEVER collapse to a single value. Emit a
+`frontend` and a `backend` sub-object inside `<techTier>`, each carrying that tier's
+`language` (and `framework` when known), so each task inherits the correct technology context.
 
-**Observation**: Each key is a package tag matching the `fe-*` / `be-*` naming convention
-used in design documents and task packages.
+**Shape**:
 
-**Constraint**: Do NOT include `packageTiers` when all packages share the same language and framework.
+`<techTier>{"stack":"fullstack","language":"typescript","frontend":{"language":"typescript","framework":"<fe-framework>"},"backend":{"language":"typescript","framework":"<be-framework>"}}</techTier>`
+
+**Constraint**: For a fullstack job, ALWAYS emit both `frontend` and `backend` sub-objects.
+Do NOT rely on the top-level `framework` to cover both tiers — it would unify two distinct
+runtimes. Single-stack jobs omit both sub-objects (the top-level `language` / `framework` is
+the sole tier).
 
 **Constraint (explicit alignment)**: If `resolvedAction.basis.techTier.<tier>.framework`
-or `.language` is set, every `packageTiers` entry whose `stack` matches that tier MUST
-emit the same `framework` / `language`. Use `packageTiers` only to encode per-package
-divergence on slots the explicit basis does not pin.
+or `.language` is set, the matching sub-object MUST emit the same `framework` / `language`.
+Use the sub-objects only to encode the per-tier framework the explicit basis does not pin.

--- a/packages/ant-cli/src/core/prompt/templates/jobs/code/nodes/revise/variants/default/rules.md
+++ b/packages/ant-cli/src/core/prompt/templates/jobs/code/nodes/revise/variants/default/rules.md
@@ -30,12 +30,18 @@ Respond with ONLY a JSON object:
       "name": "Task Name",
       "description": "What this task implements",
       "type": "setup|feature",
-      "priority": 100
+      "priority": 100,
+      "stack": "frontend|backend",
+      "include": ["<pool-path>"]
     }
   ]
 }
 ```
 
 ⚠️ **Priority**: Observe the existing tasks' priority range and assign accordingly. Lower number = earlier execution.
+
+⚠️ **Injection manifest (`include`)**: For each added task, list the artifact pool path(s) whose content the task needs pre-injected (design-doc / spec / api-contract / UI paths). Omit when the directive plus on-demand reads suffice. This is the single per-task injection field — only what you list is injected.
+
+⚠️ **Task stack (`stack`)**: Set `stack` to the runtime tier the task targets (`frontend` / `backend`). Required on fullstack jobs; omit on single-stack jobs.
 
 **Now analyze and respond with your decision in JSON format:**

--- a/packages/ant-cli/src/core/prompt/templates/jobs/design/nodes/decompose/variants/system-design/rules.md
+++ b/packages/ant-cli/src/core/prompt/templates/jobs/design/nodes/decompose/variants/system-design/rules.md
@@ -217,12 +217,13 @@ Example prefix (literal digit only):
 <fePackages>[]</fePackages>
 <consumedApis>[]</consumedApis>
 <techTier>{"stack":"<frontend | backend | fullstack>","language":"<language>","framework":"<framework or omit>"}</techTier>
-<packageTiers>{}</packageTiers>
 <targetFiles>["..."]</targetFiles>
 <tasks>
   <task>{...}</task>
 </tasks>
 ```
+
+> For fullstack, embed each runtime's framework inside `<techTier>` via `frontend` / `backend` sub-objects (see Technology Tiers below) — there is no separate per-package framework tag.
 
 #### Concrete value examples (illustrate the spectrum — pick the case that matches your observation, do NOT copy names verbatim)
 
@@ -264,25 +265,19 @@ Example prefix (literal digit only):
 
 ### Technology Tiers
 
-The `techTier` object describes the job-level technology stack (singular). When `stack` is `"fullstack"`, the `packageTiers` map provides per-package breakdowns so each task inherits the correct technology context.
+The `techTier` object describes the job-level technology stack. For a single-stack job it is `stack` + `language` + `framework`. For a fullstack job, embed a `frontend` and a `backend` sub-object so each task inherits the correct runtime's framework — FE (browser) and BE (server) are distinct runtime categories whose frameworks never collapse to one.
 
-**`techTier` (required):** Job-level summary — `stack`, `language`, `framework`.
+**`techTier` (required):** `stack`, `language`, `framework` (single-stack). For fullstack, ALSO emit `frontend` / `backend` sub-objects.
 
-**`packageTiers` (optional, fullstack/monorepo only):**
+**Fullstack shape:**
 
-| Key pattern | Meaning |
-|-------------|---------|
-| `be-main` | Backend default tier (non-MSA: exact match; MSA: tier fallback) |
-| `fe-main` | Frontend default tier (non-MSA: exact match; MSA: tier fallback) |
-| `be-{service}` | MSA backend service override (only if different from `be-main`) |
-| `fe-{package}` | Frontend package override (only if different from `fe-main`) |
+`<techTier>{"stack":"fullstack","language":"<language>","frontend":{"language":"<lang>","framework":"<fe-framework or omit>"},"backend":{"language":"<lang>","framework":"<be-framework or omit>"}}</techTier>`
 
 **Constraints:**
 - Observe language/framework mentions in directive and source documents — do NOT assume or infer technologies not explicitly stated
-- If no technology is mentioned for a tier, omit that tier's key entirely
-- For MSA: if ALL backend services share the same stack, a single `be-main` entry suffices — add `be-{service}` overrides only for services that differ
-- Value shape: `{ "language": "<language>", "framework": "<framework or omit>", "stack": "frontend" | "backend" }`
-- Do NOT include `packageTiers` when all packages share the same language and framework
+- If no technology is mentioned for a tier, omit that tier's `framework`
+- For fullstack, ALWAYS emit both `frontend` and `backend` sub-objects — do NOT rely on the top-level `framework` to cover both (it would unify two distinct runtimes)
+- Single-stack jobs omit the sub-objects (top-level `language` / `framework` is the sole tier)
 
 ### Document Type Rules
 
@@ -350,7 +345,6 @@ Each task MUST include `"parallelGroup": "<group-id>"`.
 <fePackages>[]</fePackages>
 <consumedApis>[]</consumedApis>
 <techTier>{"stack":"<stack>","language":"<language>","framework":"<framework or omit>"}</techTier>
-<packageTiers>{}</packageTiers>
 <targetFiles>["<target-file>.md"]</targetFiles>
 <tasks>
   <task>{"id":"<unique-kebab-case-id>","name":"<concise task name>","targetFile":"<must match one of targetFiles>","parallelGroup":"<group-id: same file = same group>","assignedSections":["§ <exact catalog section name>", "§ <exact catalog section name>"]{{#if sourceFileNames}},"sourceFiles":["<source filename>"]{{/if}},"description":"<abstract topic areas; section assignments are authoritative>","priority":200}</task>
@@ -399,7 +393,7 @@ Before outputting, verify:
 
 ### Output Structure
 - ✅ `<executionTier>` tag emitted FIRST, BEFORE any other meta tag
-- ✅ Each meta tag (`<documentType>`, `<services>`, `<fePackages>`, `<techTier>`, `<packageTiers>`, `<targetFiles>`, `<references>`) on its own line with a JSON-encoded body
+- ✅ Each meta tag (`<documentType>`, `<services>`, `<fePackages>`, `<techTier>`, `<targetFiles>`, `<references>`) on its own line with a JSON-encoded body
 - ✅ One `<task>{json}</task>` element per task inside `<tasks>...</tasks>`
 - ✅ NO markdown fences anywhere in the output
 - ✅ NO `<decompose>` wrapper
@@ -419,8 +413,8 @@ Before outputting, verify:
 - ✅ No forbidden tasks (deployment, ops, verification)
 {{#if sourceFileNames}}- ✅ Every task has `sourceFiles` with relevant source filenames
 {{/if}}- ✅ `<techTier>` present with `stack`, `language` (and `framework` if applicable)
-- ✅ `<packageTiers>` keys use `{tier}-main` or `{tier}-{name}` format (e.g., `be-main`, `fe-main`, `be-auth`) — only when fullstack/monorepo
-- ✅ `<packageTiers>` contains only explicitly mentioned technologies — no assumptions
+- ✅ For fullstack, `<techTier>` carries both `frontend` and `backend` sub-objects, each with its own framework — no separate per-package framework tag
+- ✅ `<techTier>` sub-objects contain only explicitly mentioned technologies — no assumptions
 - ✅ If reference project mentioned → `<references>` meta tag included
 - ✅ Every task has `parallelGroup: "<id>"`
 - ✅ Tasks targeting the same file share the same `parallelGroup`

--- a/packages/ant-cli/src/infrastructure/workspace/ArtifactService.ts
+++ b/packages/ant-cli/src/infrastructure/workspace/ArtifactService.ts
@@ -221,7 +221,8 @@ export class ArtifactService {
    * This enables token-efficient injection:
    * - Only requested sections are injected into prompts
    * - Decompose prompt receives TOC (section list) only
-   * - Plan/CodeGen prompts receive specific sections based on task.uiSections
+   * - Plan/CodeGen prompts receive specific sections based on the task's
+   *   `include` manifest (e.g. `visual/ui/ant/spec/{section}`)
    * 
    * @returns ParsedUiDocs structure with:
    *   - tokens: Full ui-tokens.json content

--- a/packages/ant-cli/src/periphery/adapters/llm/mock/decompose.ts
+++ b/packages/ant-cli/src/periphery/adapters/llm/mock/decompose.ts
@@ -6,7 +6,7 @@ export function decomposeCodeResponse(): string {
       type: 'setup',
       priority: 100,
       description: 'Initialize project structure with package.json and configuration files.',
-      packages: ['mock-app'],
+      stack: 'frontend',
     },
     {
       id: 'mock-feature',
@@ -14,7 +14,7 @@ export function decomposeCodeResponse(): string {
       type: 'feature',
       priority: 200,
       description: 'Implement the main feature as described in the directive.',
-      packages: ['mock-app'],
+      stack: 'frontend',
     },
   ]);
 

--- a/packages/ant-cli/tests/artifacts/artifact-injection-audit.test.ts
+++ b/packages/ant-cli/tests/artifacts/artifact-injection-audit.test.ts
@@ -3,7 +3,8 @@
  *
  * Static analysis that verifies:
  *   2-A. All build() callsites pass config.artifacts
- *   2-B. All decompose nodes set artifactPolicy
+ *   2-B. All decompose nodes set `include` (single injection SSOT) and the
+ *        retired `artifactPolicy` carrier is gone.
  */
 import { describe, it, expect } from 'vitest';
 import { join } from 'path';
@@ -29,19 +30,24 @@ describe('build() callsites pass config.artifacts', () => {
 });
 
 // ============================================
-// 2-B: decompose nodes must set artifactPolicy
+// 2-B: decompose nodes set `include` (single injection SSOT)
 // ============================================
 
-const MUST_SET_POLICY = [
+const MUST_SET_INCLUDE = [
   'agents/architect/graph/code/nodes/decompose/responseParser.ts',
   'agents/architect/graph/design/nodes/decompose/uiDesignDecompose.ts',
   'agents/architect/graph/design/nodes/decompose/systemDesignDecompose.ts',
   'agents/architect/graph/design/nodes/decompose/specDecompose.ts',
 ];
 
-describe('decompose nodes set artifactPolicy', () => {
-  it.each(MUST_SET_POLICY)('%s contains artifactPolicy', (file) => {
+describe('decompose nodes set include (single injection SSOT)', () => {
+  it.each(MUST_SET_INCLUDE)('%s references include', (file) => {
     const content = readFileSync(join(SRC_DIR, file), 'utf-8');
-    expect(content).toMatch(/artifactPolicy/);
+    expect(content).toMatch(/\binclude\b/);
+  });
+
+  it.each(MUST_SET_INCLUDE)('%s no longer carries the retired artifactPolicy', (file) => {
+    const content = readFileSync(join(SRC_DIR, file), 'utf-8');
+    expect(content).not.toMatch(/artifactPolicy/);
   });
 });

--- a/packages/ant-cli/tests/artifacts/artifact-pipeline.test.ts
+++ b/packages/ant-cli/tests/artifacts/artifact-pipeline.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
-  selectArtifactsWithPolicy,
-  flattenPolicyToInclude,
   appendOrUpdatePool,
   selectArtifacts,
   ArtifactPoolView,
@@ -17,10 +15,10 @@ function artifact(path: string, role: 'ref' | 'context' = 'context', content = '
 }
 
 // ---------------------------------------------------------------------------
-// selectArtifactsWithPolicy
+// selectArtifacts — single `include` SSOT (no taskType defaults)
 // ---------------------------------------------------------------------------
 
-describe('selectArtifactsWithPolicy', () => {
+describe('selectArtifacts (include SSOT)', () => {
   const pool: ResolvedArtifact[] = [
     artifact('plan', 'context', 'prd content'),
     artifact('architecture/system/fe-system-main.md', 'ref', 'fe design'),
@@ -29,87 +27,39 @@ describe('selectArtifactsWithPolicy', () => {
     artifact('visual/ui/ant/spec/header', 'context', 'header spec'),
   ];
 
-  it('refs 패턴에 매칭되는 아티팩트를 role=ref로 반환', () => {
-    const result = selectArtifactsWithPolicy(pool, {
-      refs: ['plan'],
-    });
-    expect(result).toHaveLength(1);
-    expect(result[0].path).toBe('plan');
-    expect(result[0].role).toBe('ref');
-  });
-
-  it('context 패턴에 매칭되는 아티팩트를 role=context로 반환', () => {
-    const result = selectArtifactsWithPolicy(pool, {
-      context: ['visual/ui/'],
-    });
-    expect(result.length).toBeGreaterThanOrEqual(2);
-    expect(result.every(a => a.role === 'context')).toBe(true);
-  });
-
-  it('refs와 context 모두 매칭되면 refs 우선 (seen set)', () => {
-    const result = selectArtifactsWithPolicy(pool, {
-      refs: ['plan'],
-      context: ['plan'],
-    });
-    expect(result).toHaveLength(1);
-    expect(result[0].role).toBe('ref');
-  });
-
-  it('빈 policy면 빈 배열 반환', () => {
-    expect(selectArtifactsWithPolicy(pool, {})).toEqual([]);
-    expect(selectArtifactsWithPolicy(pool, { refs: [], context: [] })).toEqual([]);
-  });
-
-  it('매칭 없으면 빈 배열 반환', () => {
-    const result = selectArtifactsWithPolicy(pool, {
-      refs: ['nonexistent/path'],
-    });
-    expect(result).toEqual([]);
-  });
-
-  it('pool 원본의 role을 policy의 role로 오버라이드', () => {
-    const result = selectArtifactsWithPolicy(pool, {
-      context: ['architecture/system/fe-system-'],
-    });
+  it('include prefix 매칭만 선택하고 role은 pool에서 상속', () => {
+    const result = selectArtifacts(pool, { include: ['architecture/system/fe-system-'] });
     expect(result).toHaveLength(1);
     expect(result[0].path).toBe('architecture/system/fe-system-main.md');
-    expect(result[0].role).toBe('context');
+    expect(result[0].role).toBe('ref'); // inherited from pool, not reassigned
   });
 
   it('glob-style trailing * 패턴 지원', () => {
-    const result = selectArtifactsWithPolicy(pool, {
-      refs: ['architecture/system/api-contract-*'],
-    });
+    const result = selectArtifacts(pool, { include: ['architecture/system/api-contract-*'] });
     expect(result).toHaveLength(1);
     expect(result[0].path).toBe('architecture/system/api-contract-auth.md');
-    expect(result[0].role).toBe('ref');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// flattenPolicyToInclude
-// ---------------------------------------------------------------------------
-
-describe('flattenPolicyToInclude', () => {
-  it('refs+context를 하나의 string[]로 합침', () => {
-    const result = flattenPolicyToInclude({
-      refs: ['architecture/spec/'],
-      context: ['visual/ui/ant/'],
-    });
-    expect(result).toEqual(['architecture/spec/', 'visual/ui/ant/']);
   });
 
-  it('undefined 입력이면 undefined 반환', () => {
-    expect(flattenPolicyToInclude(undefined)).toBeUndefined();
+  it('여러 include 경로 동시 매칭', () => {
+    const result = selectArtifacts(pool, { include: ['visual/ui/ant/', 'plan'] });
+    expect(result.map(a => a.path).sort()).toEqual([
+      'plan',
+      'visual/ui/ant/spec/header',
+      'visual/ui/ant/tokens',
+    ]);
   });
 
-  it('빈 refs+context면 undefined 반환', () => {
-    expect(flattenPolicyToInclude({ refs: [], context: [] })).toBeUndefined();
+  it('빈/누락 include → [] (taskType default 없음)', () => {
+    expect(selectArtifacts(pool, {})).toEqual([]);
+    expect(selectArtifacts(pool, { include: [] })).toEqual([]);
+    // taskType present but no include → still [] (no legacy default)
+    expect(selectArtifacts(pool, { taskType: 'ui' })).toEqual([]);
+    expect(selectArtifacts(pool, { taskType: 'feature' })).toEqual([]);
+    expect(selectArtifacts(pool, { taskType: 'error' })).toEqual([]);
   });
 
-  it('refs만 있어도 동작', () => {
-    const result = flattenPolicyToInclude({ refs: ['a', 'b'] });
-    expect(result).toEqual(['a', 'b']);
+  it('verification → [] regardless of include (defensive guard)', () => {
+    expect(selectArtifacts(pool, { taskType: 'verification', include: ['plan'] })).toEqual([]);
   });
 });
 
@@ -223,31 +173,3 @@ describe('ArtifactPoolView UI detection', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// selectArtifacts task-type defaults — ui/design-system under ant
-// ---------------------------------------------------------------------------
-
-describe('selectArtifacts ui/design-system default', () => {
-  it('ant 하위 UI 문서가 ui 태스크 기본 선택에 포함', () => {
-    const candidates = [
-      artifact('visual/ui/ant/ui-tokens.json'),
-      artifact('visual/ui/ant/ui-assets.json'),
-      artifact('architecture/system/fe-system-main.md'),
-    ];
-    const selected = selectArtifacts(candidates, { taskType: 'ui' });
-    const paths = selected.map(a => a.path).sort();
-    expect(paths).toEqual([
-      'visual/ui/ant/ui-assets.json',
-      'visual/ui/ant/ui-tokens.json',
-    ]);
-  });
-
-  it('design-system 태스크도 동일 규칙', () => {
-    const candidates = [
-      artifact('visual/ui/ant/ui-spec.json'),
-      artifact('visual/ui/ant/ui-tokens.json'),
-    ];
-    const selected = selectArtifacts(candidates, { taskType: 'design-system' });
-    expect(selected).toHaveLength(2);
-  });
-});

--- a/packages/ant-cli/tests/artifacts/artifact-policy-decompose.test.ts
+++ b/packages/ant-cli/tests/artifacts/artifact-policy-decompose.test.ts
@@ -1,128 +1,64 @@
 import { describe, it, expect } from 'vitest';
-import { deriveArtifactPolicy } from '../../src/agents/architect/graph/code/nodes/decompose/responseParser';
+import { createTaskQueue } from '../../src/agents/architect/graph/code/nodes/decompose/responseParser';
 import { ARTIFACT_PREFIX } from '@ant/shared';
 
 // ---------------------------------------------------------------------------
-// deriveArtifactPolicy
+// Per-task injection narrowing via the single `include` SSOT. Locks:
+//   1. Explicit per-task narrowing — an app task sees ONLY its own include,
+//      never a sibling (admin) task's design doc.
+//   2. RAC validation — out-of-RAC include paths are dropped in explicit mode.
 // ---------------------------------------------------------------------------
 
-describe('deriveArtifactPolicy', () => {
-  it('verification: undefined 반환', () => {
-    expect(deriveArtifactPolicy('verification')).toBeUndefined();
-  });
+const FE_APP = `${ARTIFACT_PREFIX.FE_SYSTEM}app.md`;
+const FE_ADMIN = `${ARTIFACT_PREFIX.FE_SYSTEM}admin.md`;
+const API = `${ARTIFACT_PREFIX.API_CONTRACT}main.md`;
 
-  it('ui taskType: uiSections -> context paths', () => {
-    const result = deriveArtifactPolicy('ui', undefined, ['header', 'tokens', 'assets']);
-    expect(result).toBeDefined();
-    expect(result!.context).toBeDefined();
-    expect(result!.refs).toBeUndefined();
-    expect(result!.context).toContain(`${ARTIFACT_PREFIX.UI_ANT}tokens`);
-    expect(result!.context).toContain(`${ARTIFACT_PREFIX.UI_ANT}assets`);
-    expect(result!.context).toContain(`${ARTIFACT_PREFIX.UI_ANT_SPEC}header`);
-  });
+function tier3(tasks: any[]) {
+  return [
+    ...tasks,
+    { id: 'final-verification', name: 'Final Verification', type: 'verification' as const, priority: 1000, description: 'Verify' },
+  ] as any;
+}
 
-  it('design-system taskType: uiSections -> context paths', () => {
-    const result = deriveArtifactPolicy('design-system', undefined, ['layout']);
-    expect(result).toBeDefined();
-    expect(result!.context).toContain(`${ARTIFACT_PREFIX.UI_ANT}tokens`);
-    expect(result!.context).toContain(`${ARTIFACT_PREFIX.UI_ANT_SPEC}layout`);
-  });
+describe('explicit per-task narrowing (app task does not receive admin doc)', () => {
+  const racScope = { refs: [FE_APP, FE_ADMIN, API], context: [] };
 
-  it('ui taskType: no uiSections -> wildcard context', () => {
-    const result = deriveArtifactPolicy('ui');
-    expect(result).toBeDefined();
-    expect(result!.context).toContain(`${ARTIFACT_PREFIX.UI_ANT}*`);
-  });
-
-  it('fe-/be- packages -> refs paths', () => {
-    const result = deriveArtifactPolicy('feature', ['fe-main', 'be-auth']);
-    expect(result).toBeDefined();
-    expect(result!.refs).toContain(`${ARTIFACT_PREFIX.FE_SYSTEM}main.md`);
-    expect(result!.refs).toContain(`${ARTIFACT_PREFIX.BE_SYSTEM}auth.md`);
-    expect(result!.refs).toContain(`${ARTIFACT_PREFIX.API_CONTRACT}*`);
-  });
-
-  it('shared package -> api-contract ref', () => {
-    const result = deriveArtifactPolicy('feature', ['shared']);
-    expect(result).toBeDefined();
-    expect(result!.refs).toContain(`${ARTIFACT_PREFIX.API_CONTRACT}*`);
-  });
-
-  it('active spec ref filename -> spec ref', () => {
-    const result = deriveArtifactPolicy('feature', undefined, undefined, 'spec-login.md');
-    expect(result).toBeDefined();
-    expect(result!.refs).toContain(`${ARTIFACT_PREFIX.SPEC}spec-login.md`);
-  });
-
-  it('packages without shared -> still includes api-contract', () => {
-    const result = deriveArtifactPolicy('feature', ['fe-main']);
-    expect(result).toBeDefined();
-    expect(result!.refs).toContain(`${ARTIFACT_PREFIX.API_CONTRACT}*`);
-  });
-
-  it('no packages, no spec -> undefined', () => {
-    const result = deriveArtifactPolicy('feature');
-    expect(result).toBeUndefined();
-  });
-
-  // ─────────────────────────────────────────────────────────────────
-  // Channel B closure — explicit pipeline suppresses package→ref
-  // synthesis (`discovery-tool RAC bypass (2026-04)` regression).
-  // ─────────────────────────────────────────────────────────────────
-
-  it('explicit mode + fe-main packages -> no refs synthesis', () => {
-    const result = deriveArtifactPolicy(
-      'feature',
-      ['fe-main'],
-      undefined,
-      undefined,
-      undefined,
-      'explicit',
+  it('app task include = [fe-system-app, api-contract]; admin doc absent', () => {
+    const { taskQueue } = createTaskQueue(
+      tier3([
+        { id: 'app', name: 'App', type: 'feature', priority: 300, stack: 'frontend', include: [FE_APP, API] },
+        { id: 'admin', name: 'Admin', type: 'feature', priority: 301, stack: 'frontend', include: [FE_ADMIN, API] },
+      ]),
+      null, undefined, 3, racScope,
     );
-    expect(result).toBeUndefined();
+    const app = taskQueue.getAll().find(t => t.id === 'app')!;
+    const admin = taskQueue.getAll().find(t => t.id === 'admin')!;
+    expect(app.include).toEqual([FE_APP, API]);
+    expect(app.include).not.toContain(FE_ADMIN);
+    expect(admin.include).toEqual([FE_ADMIN, API]);
+    expect(admin.include).not.toContain(FE_APP);
   });
 
-  it('explicit mode + shared package -> no api-contract synthesis', () => {
-    const result = deriveArtifactPolicy(
-      'feature',
-      ['shared'],
-      undefined,
-      undefined,
-      undefined,
-      'explicit',
+  it('out-of-RAC include path is dropped (RAC validation)', () => {
+    const { taskQueue } = createTaskQueue(
+      tier3([
+        { id: 'app', name: 'App', type: 'feature', priority: 300, stack: 'frontend', include: [FE_APP, FE_ADMIN] },
+      ]),
+      null, undefined, 3,
+      { refs: [FE_APP], context: [] }, // admin NOT in RAC
     );
-    expect(result).toBeUndefined();
+    const app = taskQueue.getAll().find(t => t.id === 'app')!;
+    expect(app.include).toEqual([FE_APP]);
   });
 
-  it('explicit mode preserves spec ref derived from RAC', () => {
-    const result = deriveArtifactPolicy(
-      'feature',
-      ['fe-main'],
-      undefined,
-      'spec-login.md',
-      undefined,
-      'explicit',
+  it('retired carriers (artifactPolicy / packages / uiSections) are not set', () => {
+    const { taskQueue } = createTaskQueue(
+      tier3([{ id: 'app', name: 'App', type: 'feature', priority: 300, stack: 'frontend', include: [FE_APP] }]),
+      null, undefined, 3, racScope,
     );
-    expect(result?.refs).toEqual([`${ARTIFACT_PREFIX.SPEC}spec-login.md`]);
-  });
-
-  it('explicit mode preserves UI/design-system uiSections branch (slot already in RAC)', () => {
-    const result = deriveArtifactPolicy(
-      'design-system',
-      undefined,
-      ['layout'],
-      undefined,
-      undefined,
-      'explicit',
-    );
-    expect(result?.context).toContain(`${ARTIFACT_PREFIX.UI_ANT}tokens`);
-    expect(result?.context).toContain(`${ARTIFACT_PREFIX.UI_ANT_SPEC}layout`);
-  });
-
-  it('default mode is infer (backward-compat)', () => {
-    // No 6th arg → infer behaviour preserved for any caller that has
-    // not been updated yet.
-    const result = deriveArtifactPolicy('feature', ['fe-main']);
-    expect(result?.refs).toContain(`${ARTIFACT_PREFIX.FE_SYSTEM}main.md`);
+    const app = taskQueue.getAll().find(t => t.id === 'app')! as any;
+    expect(app.artifactPolicy).toBeUndefined();
+    expect(app.packages).toBeUndefined();
+    expect(app.uiSections).toBeUndefined();
   });
 });

--- a/packages/ant-cli/tests/policy/rac-scope-invariant.test.ts
+++ b/packages/ant-cli/tests/policy/rac-scope-invariant.test.ts
@@ -1,32 +1,14 @@
 /**
  * RAC scope invariant — `state.artifacts ⊆ resolvedAction.refs ∪ context`.
  *
- * Locks the post-RAC SSOT introduced after the `post-RAC pool-leak (2026-04)`
- * regression: a wholesale `architecture/system/**` load on the resolve
- * node injected `fe-system-main.md` into a `gen-code-directive` job whose
- * RAC explicitly excluded system-design slots. The leak surfaced through
- * three independent channels — decompose `tierRefs`, decompose `documents`,
- * and `deriveArtifactPolicy` package mapping — yet none was strictly
- * RAC-bounded. Pinning the pool itself to the RAC subset closes all three
- * at once. See `AGENTS.md` "state.artifacts Post-RAC SSOT".
- *
- * The `discovery-tool RAC bypass (2026-04)` follow-up regression (Apr 26 2026) showed the
- * pool fix alone was insufficient: two compensating channels remained —
- *
- *   Channel A: decompose `discoveryTools` (`read_file` / `list_files`,
- *              scope=`artifact`) bypassed the RAC entirely because its
- *              path validation only checked traversal/root containment.
- *              Closure: explicit RAC injects a `racScope` whitelist so
- *              tool calls outside `refs ∪ context` are rejected.
- *
- *   Channel B: `deriveArtifactPolicy` synthesised `refs` paths from the
- *              LLM's `packages` tag (e.g. `fe-main → fe-system-main.md`)
- *              regardless of pool membership. Closure: the function
- *              accepts an `ArtifactPolicyMode`; explicit pipelines
- *              suppress package→ref mapping.
- *
- * The Channel A/B locks live in this file so a single regression test
- * suite covers every leak path that has ever bypassed the pool SSOT.
+ * Locks the post-RAC SSOT: `state.artifacts` is pinned to the RAC subset, so
+ * a wholesale `architecture/system/**` load can no longer inject docs the RAC
+ * excluded. The decompose `read_file` / `list_files` tool calls are RAC-scoped
+ * via `computeRacScope(resolvedAction)` + `decideRacGate` (explicit pipeline
+ * only); the same gate runs at the shared code `tool` node so plan/execute
+ * reads are RAC-scoped symmetrically (SSOT: `racGate.ts`). Per-task injection
+ * is the single LLM-authored, RAC-validated `include` field — a task sees only
+ * its own `include`. See `AGENTS.md` "state.artifacts Post-RAC SSOT".
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -36,11 +18,11 @@ import * as os from 'os';
 import { loadResolvedArtifacts } from '../../src/agents/common/graph/loadDocumentsForRAC';
 import {
   createTaskQueue,
-  deriveArtifactPolicy,
 } from '../../src/agents/architect/graph/code/nodes/decompose/responseParser';
 import {
   decideRacGate,
   isWithinRacWhitelist,
+  computeRacScope,
   type RacScope,
 } from '../../src/agents/architect/graph/code/nodes/decompose/racGate';
 import { handleReadFile, handleListFiles } from '../../src/agents/common/tool/handlers';
@@ -325,108 +307,85 @@ describe('decompose RAC whitelist (Channel A — `discovery-tool RAC bypass (202
 });
 
 // ───────────────────────────────────────────────────────────────────────
-// Channel B — deriveArtifactPolicy / createTaskQueue must respect mode
+// computeRacScope — explicit-only RAC scope derivation
 // ───────────────────────────────────────────────────────────────────────
 
-describe('deriveArtifactPolicy mode gate (Channel B — `discovery-tool RAC bypass (2026-04)`)', () => {
-  it('explicit mode + fe-main packages → no auto refs synthesis', () => {
-    const result = deriveArtifactPolicy(
-      'feature',
-      ['fe-main'],
-      undefined,
-      undefined,
-      undefined,
-      'explicit',
-    );
-    expect(result).toBeUndefined();
+describe('computeRacScope', () => {
+  it('explicit pipeline with non-empty RAC → scope', () => {
+    const scope = computeRacScope({
+      source: 'explicit',
+      hasExplicitFields: true,
+      refs: ['plan/prd.md'],
+      context: [],
+    } as any);
+    expect(scope).toEqual({ refs: ['plan/prd.md'], context: [] });
   });
 
-  it('explicit mode + spec ref still surfaces the spec (RAC-derived)', () => {
-    // The active spec is pulled from the RAC pool view, not the
-    // packages mapping, so it must survive even in explicit mode —
-    // suppressing it would hide a legitimately user-selected file.
-    const result = deriveArtifactPolicy(
-      'feature',
-      ['fe-main'],
-      undefined,
-      'spec-login.md',
-      undefined,
-      'explicit',
-    );
-    expect(result?.refs).toEqual([`${ARTIFACT_PREFIX.SPEC}spec-login.md`]);
+  it('infer pipeline → undefined (everything allowed downstream)', () => {
+    expect(computeRacScope({ source: 'infer', hasExplicitFields: false, refs: [], context: [] } as any)).toBeUndefined();
   });
 
-  it('infer mode keeps the legacy package → fe-system-main.md mapping', () => {
-    const result = deriveArtifactPolicy(
-      'feature',
-      ['fe-main'],
-      undefined,
-      undefined,
-      undefined,
-      'infer',
-    );
-    expect(result?.refs).toContain(`${ARTIFACT_PREFIX.FE_SYSTEM}main.md`);
-    expect(result?.refs).toContain(`${ARTIFACT_PREFIX.API_CONTRACT}*`);
+  it('explicit but empty RAC → undefined (LLM must discover anchors)', () => {
+    expect(computeRacScope({ source: 'explicit', hasExplicitFields: true, refs: [], context: [] } as any)).toBeUndefined();
   });
 });
 
-describe('createTaskQueue mode gate — explicit pipeline produces RAC-only task.include', () => {
-  it('Tier 3 explicit pipeline: no fe-system-main.md leaks into task.include', () => {
-    // Reproduces `discovery-tool RAC bypass (2026-04)` task shape: gen-code-directive
-    // with PRD-only RAC, decompose LLM emits `packages: ["fe-main"]`.
-    // Explicit mode must NOT bake `architecture/system/fe-system-main.md`
-    // into the task.
-    const tasks = [
-      {
-        id: 'feature-navbar',
-        name: 'Feature: Navbar',
-        type: 'feature' as const,
-        priority: 300,
-        description: 'Implement navbar',
-        packages: ['fe-main'],
-      },
-      {
-        id: 'final-verification',
-        name: 'Final Verification',
-        type: 'verification' as const,
-        priority: 1000,
-        description: 'Verify',
-      },
-    ] as any;
+// ───────────────────────────────────────────────────────────────────────
+// createTaskQueue — LLM-authored `include`, RAC-validated
+// ───────────────────────────────────────────────────────────────────────
 
-    const { taskQueue } = createTaskQueue(tasks, null, undefined, 3, 'explicit');
+describe('createTaskQueue include RAC validation', () => {
+  const baseTasks = (include: string[]) => ([
+    {
+      id: 'feature-navbar',
+      name: 'Feature: Navbar',
+      type: 'feature' as const,
+      priority: 300,
+      description: 'Implement navbar',
+      stack: 'frontend',
+      include,
+    },
+    {
+      id: 'final-verification',
+      name: 'Final Verification',
+      type: 'verification' as const,
+      priority: 1000,
+      description: 'Verify',
+    },
+  ] as any);
+
+  it('explicit pipeline: include paths outside RAC are dropped', () => {
+    // RAC pinned to PRD only; LLM authored an out-of-RAC system-design path.
+    const racScope = { refs: ['plan/prd.md'], context: [] };
+    const { taskQueue } = createTaskQueue(
+      baseTasks(['plan/prd.md', 'architecture/system/fe-system-main.md']),
+      null, undefined, 3, racScope,
+    );
     const navbar = taskQueue.getAll().find(t => t.id === 'feature-navbar')!;
-
-    expect(navbar.artifactPolicy).toBeUndefined();
-    expect(navbar.include ?? []).not.toContain('architecture/system/fe-system-main.md');
-    expect(navbar.include ?? []).not.toContain('architecture/system/api-contract-*');
-    // packages survives as a tech-tier hint.
-    expect(navbar.packages).toEqual(['fe-main']);
+    expect(navbar.include).toEqual(['plan/prd.md']);
+    expect(navbar.include).not.toContain('architecture/system/fe-system-main.md');
+    // retired carriers are gone
+    expect((navbar as any).artifactPolicy).toBeUndefined();
+    expect((navbar as any).packages).toBeUndefined();
   });
 
-  it('Tier 3 infer pipeline: legacy fe-main → fe-system-main.md path remains', () => {
-    const tasks = [
-      {
-        id: 'feature-navbar',
-        name: 'Feature: Navbar',
-        type: 'feature' as const,
-        priority: 300,
-        description: 'Implement navbar',
-        packages: ['fe-main'],
-      },
-      {
-        id: 'final-verification',
-        name: 'Final Verification',
-        type: 'verification' as const,
-        priority: 1000,
-        description: 'Verify',
-      },
-    ] as any;
-
-    const { taskQueue } = createTaskQueue(tasks, null, undefined, 3, 'infer');
+  it('explicit pipeline: in-RAC include survives; stack preserved', () => {
+    const racScope = { refs: ['plan/prd.md', 'architecture/system/api-contract-main.md'], context: [] };
+    const { taskQueue } = createTaskQueue(
+      baseTasks(['architecture/system/api-contract-main.md']),
+      null, undefined, 3, racScope,
+    );
     const navbar = taskQueue.getAll().find(t => t.id === 'feature-navbar')!;
+    expect(navbar.include).toEqual(['architecture/system/api-contract-main.md']);
+    expect(navbar.stack).toBe('frontend');
+  });
 
-    expect(navbar.artifactPolicy?.refs).toContain(`${ARTIFACT_PREFIX.FE_SYSTEM}main.md`);
-    expect(navbar.include ?? []).toContain(`${ARTIFACT_PREFIX.FE_SYSTEM}main.md`);
+  it('infer pipeline (racScope undefined): include passes through unvalidated', () => {
+    const { taskQueue } = createTaskQueue(
+      baseTasks(['architecture/system/fe-system-main.md']),
+      null, undefined, 3, undefined,
+    );
+    const navbar = taskQueue.getAll().find(t => t.id === 'feature-navbar')!;
+    expect(navbar.include).toEqual(['architecture/system/fe-system-main.md']);
   });
 });

--- a/packages/ant-cli/tests/policy/techtier-propagation.test.ts
+++ b/packages/ant-cli/tests/policy/techtier-propagation.test.ts
@@ -3,7 +3,7 @@
  *
  * Verifies that:
  * - buildTechTier correctly constructs TechTier from codebase profile
- * - resolveTaskTechTiersFromMap maps packages to per-task tiers
+ * - resolveTaskTechTierFromStack maps a task's `stack` pointer to its tier
  * - applyExplicitTechTierOverrides preserves explicit basis over LLM emit
  * - effectiveTechTier collapses multiple tiers into one
  * - Jobs without decompose (plan, ask, visual) work without techTier
@@ -13,12 +13,12 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildTechTier,
-  resolveTaskTechTiersFromMap,
+  resolveTaskTechTierFromStack,
   applyExplicitTechTierOverrides,
   effectiveTechTier,
   resolveToRAC,
 } from '@ant/shared';
-import type { TechTier, TechTierConfig, PackageTierEntry } from '@ant/shared';
+import type { TechTier, TechTierConfig } from '@ant/shared';
 import { AutoInjectionResolver } from '../../src/core/prompt/builder/AutoInjectionResolver';
 
 const resolver = new AutoInjectionResolver();
@@ -67,69 +67,64 @@ describe('buildTechTier', () => {
 // tests/core/rac.test.ts (the @ant/shared normalisation SSOT).
 
 // ============================================
-// resolveTaskTechTiersFromMap
+// resolveTaskTechTierFromStack — per-task stack pointer → config slot
 // ============================================
 
-describe('resolveTaskTechTiersFromMap', () => {
-  const config: TechTierConfig = {
+describe('resolveTaskTechTierFromStack', () => {
+  // Fullstack config with DISTINCT frameworks per tier — the non-collapse
+  // invariant (Next front + Express back must not merge into one framework).
+  const fullstack: TechTierConfig = {
     stack: 'fullstack',
     frontend: { language: 'typescript', framework: 'nextjs', stack: 'frontend' },
-    backend: { language: 'typescript', framework: 'nextjs', stack: 'backend' },
+    backend: { language: 'typescript', framework: 'express', stack: 'backend' },
   };
 
-  const packageTiers: Record<string, PackageTierEntry> = {
-    'fe-main': { language: 'typescript', framework: 'react', stack: 'frontend' },
-    'be-api': { language: 'typescript', framework: 'nestjs', stack: 'backend' },
-    'be-go': { language: 'go', framework: 'gin', stack: 'backend' },
-  };
-
-  it('no packages → all tiers from config', () => {
-    const tiers = resolveTaskTechTiersFromMap(undefined, config, packageTiers);
-    expect(tiers).toHaveLength(2);
+  it('stack=frontend → [config.frontend] (framework not collapsed)', () => {
+    const tiers = resolveTaskTechTierFromStack('frontend', fullstack);
+    expect(tiers).toHaveLength(1);
+    expect(tiers[0].stack).toBe('frontend');
+    expect(tiers[0].framework).toBe('nextjs');
   });
 
-  it('no config → empty', () => {
-    expect(resolveTaskTechTiersFromMap(['fe-main'], undefined, packageTiers)).toEqual([]);
-  });
-
-  it('uses packageTier entry values over config values', () => {
-    const tiers = resolveTaskTechTiersFromMap(['be-api'], config, packageTiers);
+  it('stack=backend → [config.backend] (distinct from frontend)', () => {
+    const tiers = resolveTaskTechTierFromStack('backend', fullstack);
     expect(tiers).toHaveLength(1);
     expect(tiers[0].stack).toBe('backend');
-    expect(tiers[0].framework).toBe('nestjs');
-    expect(tiers[0].language).toBe('typescript');
+    expect(tiers[0].framework).toBe('express');
   });
 
-  it('frontend package gets entry framework', () => {
-    const tiers = resolveTaskTechTiersFromMap(['fe-main'], config, packageTiers);
+  it('fullstack frameworks do NOT collapse: fe=nextjs ≠ be=express', () => {
+    const fe = resolveTaskTechTierFromStack('frontend', fullstack)[0];
+    const be = resolveTaskTechTierFromStack('backend', fullstack)[0];
+    expect(fe.framework).not.toBe(be.framework);
+  });
+
+  it('no config → []', () => {
+    expect(resolveTaskTechTierFromStack('frontend', undefined)).toEqual([]);
+  });
+
+  it('stack omitted on single-stack config → the sole tier', () => {
+    const single: TechTierConfig = {
+      stack: 'frontend',
+      frontend: { language: 'typescript', framework: 'react', stack: 'frontend' },
+    };
+    const tiers = resolveTaskTechTierFromStack(undefined, single);
     expect(tiers).toHaveLength(1);
     expect(tiers[0].framework).toBe('react');
   });
 
-  it('mixed packages → two tiers with correct frameworks', () => {
-    const tiers = resolveTaskTechTiersFromMap(['fe-main', 'be-api'], config, packageTiers);
-    expect(tiers).toHaveLength(2);
-    const fe = tiers.find(t => t.stack === 'frontend');
-    const be = tiers.find(t => t.stack === 'backend');
-    expect(fe?.framework).toBe('react');
-    expect(be?.framework).toBe('nestjs');
+  it('stack given but that slot empty → []', () => {
+    const single: TechTierConfig = {
+      stack: 'frontend',
+      frontend: { language: 'typescript', stack: 'frontend' },
+    };
+    expect(resolveTaskTechTierFromStack('backend', single)).toEqual([]);
   });
 
-  it('go backend package uses entry language', () => {
-    const tiers = resolveTaskTechTiersFromMap(['be-go'], config, packageTiers);
+  it('stack omitted on fullstack config → contract-violation fallback to frontend', () => {
+    const tiers = resolveTaskTechTierFromStack(undefined, fullstack);
     expect(tiers).toHaveLength(1);
-    expect(tiers[0].language).toBe('go');
-    expect(tiers[0].framework).toBe('gin');
-  });
-
-  it('unmapped packages → falls back to all config tiers', () => {
-    const tiers = resolveTaskTechTiersFromMap(['unknown-pkg'], config, packageTiers);
-    expect(tiers).toHaveLength(2);
-  });
-
-  it('deduplicates by stack key', () => {
-    const tiers = resolveTaskTechTiersFromMap(['fe-main', 'fe-main'], config, packageTiers);
-    expect(tiers).toHaveLength(1);
+    expect(tiers[0].stack).toBe('frontend');
   });
 });
 
@@ -138,7 +133,7 @@ describe('resolveTaskTechTiersFromMap', () => {
 //
 // Policy: explicit basis from `actionMetadata.basis.techTier` is authoritative.
 // Mirrors the visualTier / gameArtTier / gameContentTier invariant — preset
-// fields win over LLM-emitted packageTiers entries for the same stack.
+// fields win over LLM-emitted `<techTier>` values for the same stack.
 // ============================================
 
 describe('applyExplicitTechTierOverrides', () => {
@@ -204,40 +199,33 @@ describe('applyExplicitTechTierOverrides', () => {
     expect(out[0].gameEngine).toBe('phaser');
   });
 
-  it('end-to-end: explicit nextjs survives LLM packageTiers emitting react', () => {
+  it('end-to-end: explicit nextjs survives a config frontend framework of react', () => {
+    // Config (LLM-derived) has react on frontend; explicit basis pins nextjs.
     const config: TechTierConfig = {
       stack: 'frontend',
-      frontend: { language: 'typescript', framework: 'nextjs', stack: 'frontend' },
-    };
-    const llmEmittedPackageTiers: Record<string, PackageTierEntry> = {
-      'fe-main': { language: 'typescript', framework: 'react', stack: 'frontend' },
+      frontend: { language: 'typescript', framework: 'react', stack: 'frontend' },
     };
     const explicit: TechTierConfig = {
       stack: 'frontend',
       frontend: { framework: 'nextjs', stack: 'frontend' },
     };
-    const resolved = resolveTaskTechTiersFromMap(['fe-main'], config, llmEmittedPackageTiers);
+    const resolved = resolveTaskTechTierFromStack('frontend', config);
     const final = applyExplicitTechTierOverrides(resolved, explicit);
     expect(final).toHaveLength(1);
     expect(final[0].framework).toBe('nextjs');
     expect(final[0].stack).toBe('frontend');
   });
 
-  it('end-to-end without explicit: monorepo packageTiers divergence preserved', () => {
+  it('end-to-end without explicit: per-stack framework divergence preserved', () => {
     const config: TechTierConfig = {
       stack: 'fullstack',
-      frontend: { language: 'typescript', stack: 'frontend' },
-      backend: { language: 'typescript', stack: 'backend' },
+      frontend: { language: 'typescript', framework: 'react', stack: 'frontend' },
+      backend: { language: 'typescript', framework: 'express', stack: 'backend' },
     };
-    const llmEmittedPackageTiers: Record<string, PackageTierEntry> = {
-      'fe-main': { language: 'typescript', framework: 'react', stack: 'frontend' },
-      'be-api': { language: 'typescript', framework: 'express', stack: 'backend' },
-    };
-    const resolved = resolveTaskTechTiersFromMap(['fe-main', 'be-api'], config, llmEmittedPackageTiers);
-    const final = applyExplicitTechTierOverrides(resolved, undefined);
-    expect(final).toHaveLength(2);
-    expect(final.find(t => t.stack === 'frontend')?.framework).toBe('react');
-    expect(final.find(t => t.stack === 'backend')?.framework).toBe('express');
+    const fe = applyExplicitTechTierOverrides(resolveTaskTechTierFromStack('frontend', config), undefined);
+    const be = applyExplicitTechTierOverrides(resolveTaskTechTierFromStack('backend', config), undefined);
+    expect(fe[0].framework).toBe('react');
+    expect(be[0].framework).toBe('express');
   });
 });
 
@@ -373,28 +361,23 @@ describe('E2E: decompose techTier → injection chain', () => {
     expect(injections).not.toContain('jobs/code/base/injections/preview-setup');
   });
 
-  it('simulates fullstack multi-package decompose → execute flow', () => {
-    const packageTiers: Record<string, PackageTierEntry> = {
-      'fe-main': { language: 'typescript', framework: 'nextjs', stack: 'frontend' },
-      'be-api': { language: 'typescript', framework: 'express', stack: 'backend' },
-    };
+  it('simulates fullstack decompose → per-stack task tiers → execute flow', () => {
     const config: TechTierConfig = {
       stack: 'fullstack',
-      frontend: { language: 'typescript', stack: 'frontend' },
-      backend: { language: 'typescript', stack: 'backend' },
+      frontend: { language: 'typescript', framework: 'nextjs', stack: 'frontend' },
+      backend: { language: 'typescript', framework: 'express', stack: 'backend' },
     };
-    const taskTiers = resolveTaskTechTiersFromMap(['fe-main', 'be-api'], config, packageTiers);
+    // Each task narrows to a single stack via its `stack` pointer.
+    const feTiers = resolveTaskTechTierFromStack('frontend', config);
+    const beTiers = resolveTaskTechTierFromStack('backend', config);
+    expect(feTiers[0].framework).toBe('nextjs');
+    expect(beTiers[0].framework).toBe('express');
 
-    expect(taskTiers).toHaveLength(2);
-
-    const eff = effectiveTechTier(taskTiers);
-    expect(eff.stack).toBeUndefined();
-
+    // A backend task surfaces the backend-safety injection.
     const injections = resolver.resolve({
       job: 'code', node: 'execute', taskType: 'feature',
-      techTiers: taskTiers, data: {},
+      techTiers: beTiers, data: {},
     });
-
     expect(injections).toContain('jobs/code/nodes/execute/injections/backend-safety');
   });
 

--- a/packages/ant-cli/tests/prompt/prompt-integration.test.ts
+++ b/packages/ant-cli/tests/prompt/prompt-integration.test.ts
@@ -33,53 +33,52 @@ function rac(overrides?: Partial<ResolvedActionContext>): ResolvedActionContext 
 // ============================================================================
 
 describe('Integration A: ArtifactPipeline (artifact pool + selectArtifacts)', () => {
-  it('feature task with design artifacts → selected by default', () => {
+  it('feature task with authored include → design doc selected', () => {
     const pool: ResolvedArtifact[] = [
       { path: 'architecture/system/fe-system-main.md', content: '# Frontend System Design\nNext.js app', role: 'ref' },
     ];
-    expect(pool.some(a => a.path.includes('fe-system-main'))).toBe(true);
-
-    const selected = selectArtifacts(pool, { taskType: 'feature' });
+    const selected = selectArtifacts(pool, { taskType: 'feature', include: ['architecture/system/fe-system-main.md'] });
     expect(selected.some(a => a.content.includes('Frontend System Design'))).toBe(true);
   });
 
-  it('verification task → empty selection regardless of pool', () => {
+  it('verification task → empty selection regardless of include', () => {
     const pool: ResolvedArtifact[] = [
       { path: 'architecture/system/fe-system-main.md', content: 'Design', role: 'ref' },
     ];
-    expect(pool.length).toBeGreaterThan(0);
-
-    const selected = selectArtifacts(pool, { taskType: 'verification' });
+    const selected = selectArtifacts(pool, { taskType: 'verification', include: ['architecture/system/fe-system-main.md'] });
     expect(selected).toHaveLength(0);
   });
 
-  it('error task without spec → empty selection', () => {
+  it('no include → empty selection (no taskType default)', () => {
     const pool: ResolvedArtifact[] = [
       { path: 'architecture/system/fe-system-main.md', content: 'Design', role: 'ref' },
     ];
-    const selected = selectArtifacts(pool, { taskType: 'error' });
-    expect(selected).toHaveLength(0);
+    expect(selectArtifacts(pool, { taskType: 'error' })).toHaveLength(0);
+    expect(selectArtifacts(pool, { taskType: 'feature' })).toHaveLength(0);
   });
 
-  it('error task with specDocs in pool → spec selected', () => {
+  it('error task with spec/api-contract include → both selected', () => {
     const pool: ResolvedArtifact[] = [
       { path: 'architecture/system/api-contract-main.md', content: 'API contract', role: 'ref' },
       { path: 'architecture/spec/spec-login', content: 'Login feature spec', role: 'ref' },
     ];
-    const selected = selectArtifacts(pool, { taskType: 'error' });
+    const selected = selectArtifacts(pool, {
+      taskType: 'error',
+      include: ['architecture/spec/', 'architecture/system/api-contract-'],
+    });
     expect(selected.some(a => a.path.includes('spec-login'))).toBe(true);
     expect(selected.some(a => a.path.includes('api-contract'))).toBe(true);
   });
 
-  it('ui task → only UI docs selected', () => {
+  it('ui task with UI include → only the listed UI docs selected', () => {
     const pool: ResolvedArtifact[] = [
       { path: 'architecture/system/fe-system-main.md', content: 'FE design', role: 'ref' },
       { path: 'visual/ui/ant/tokens', content: '{ "colors": {} }', role: 'context' },
       { path: 'visual/ui/ant/spec/header', content: 'Header spec', role: 'context' },
     ];
-    const selected = selectArtifacts(pool, { taskType: 'ui' });
+    const selected = selectArtifacts(pool, { taskType: 'ui', include: ['visual/ui/ant/'] });
     expect(selected.every(a => a.path.startsWith('visual/ui/ant/'))).toBe(true);
-    expect(selected.length).toBeGreaterThan(0);
+    expect(selected.length).toBe(2);
   });
 
   it('include patterns → exact path matching', () => {

--- a/packages/ant-cli/tests/prompt/role-flag-intent-matrix.test.ts
+++ b/packages/ant-cli/tests/prompt/role-flag-intent-matrix.test.ts
@@ -130,10 +130,9 @@ describe('role-flag intent matrix — post-RAC Gate guarantees', () => {
     expect(s.hasSpec).toBe(true);
     expect(s.hasSpecRef).toBe(true);
 
-    // System-design is context — Contract flag OFF (plan's "API Contract
-    // IMMUTABLE" must NOT fire from this slot alone; it re-fires later
-    // via package-mapping in `deriveArtifactPolicy` which is out of
-    // scope for this slot-level test).
+    // System-design surfaces as a Gate flag (`hasSystemDesign`) regardless of
+    // role — the plan's "API Contract IMMUTABLE" guidance gates on presence,
+    // not on this slot-level role distinction.
     expect(s.hasSystemDesign).toBe(true);
     expect(s.hasSystemDesignRef).toBe(false);
     expect(s.hasSystemDesignContext).toBe(true);
@@ -183,9 +182,9 @@ describe('role-flag intent matrix — post-RAC Gate guarantees', () => {
 
   it('explicit override path — user-promoted UI refs bypass the intent default', () => {
     // When the user explicitly selects UI as refs in a gen-code-spec
-    // request (e.g. via the Action footer), `selectArtifactsWithPolicy`
-    // re-stamps role='ref' on the selected artifacts. The Contract
-    // flag then fires without any change to the intent matrix.
+    // request (e.g. via the Action footer), the RAC pool annotates those
+    // artifacts role='ref'. The Contract flag then fires without any
+    // change to the intent matrix (role is inherited from the pool).
     const userPromoted: ResolvedArtifact[] = [
       { path: 'visual/ui/ant/ui-spec.json', content: '{}', role: 'ref' },
     ];

--- a/packages/ant-cli/tests/tasks/design-system/hooks.test.ts
+++ b/packages/ant-cli/tests/tasks/design-system/hooks.test.ts
@@ -122,10 +122,9 @@ describe('tasks/design-system/hooks/conversations', () => {
 
 describe('tasks/design-system/model/is — isDesignSystemTask', () => {
   // Introduced in T6b-κ together with isTestCodeTask / isExplainTask so
-  // phase-layer call sites (`nodes/execute/tools.ts
-  // isFrontendTask`, `nodes/decompose/responseParser.ts
-  // deriveArtifactPolicy`) can retire the last literal
-  // `taskType === 'design-system'` comparisons and delegate to the
+  // phase-layer call sites (`nodes/execute/tools.ts isFrontendTask`,
+  // `nodes/decompose/responseParser.ts` task building) can retire the last
+  // literal `taskType === 'design-system'` comparisons and delegate to the
   // per-task predicate SSOT.
   it('returns true only for design-system tasks', () => {
     expect(isDesignSystemTask({ type: 'design-system' })).toBe(true);

--- a/packages/ant-cli/tests/verification/unit/batchSplitBandCarryover.test.ts
+++ b/packages/ant-cli/tests/verification/unit/batchSplitBandCarryover.test.ts
@@ -183,6 +183,64 @@ describe('batchSplit — Three-Axis SSOT priority + band semantics', () => {
     }
   });
 
+  it('Path B (error parent): sub-tasks inherit the parent include + stack', () => {
+    const state = makeState();
+    const parent: CodeTask = {
+      id: 'err-1',
+      name: 'fix errors',
+      type: 'error',
+      priority: 905,
+      description: '',
+      stack: 'backend',
+      include: ['architecture/system/be-system-main.md', 'architecture/system/api-contract-main.md'],
+    } as CodeTask;
+    const plan = JSON.stringify({
+      batches: [
+        { name: 'fix a', rationale: 'error in a', modify: [{ target: 'a.ts' }] },
+        { name: 'fix b', rationale: 'error in b', modify: [{ target: 'b.ts' }] },
+      ],
+    });
+
+    processDiagnosticBatchSplit(state, plan, parent);
+
+    const subs = state.taskQueue.getAll().filter((t: any) => t.type === 'error');
+    expect(subs.length).toBe(2);
+    for (const s of subs) {
+      expect((s as any).include).toEqual(parent.include);
+      expect((s as any).stack).toBe('backend');
+    }
+  });
+
+  it('Path A (verification parent): error sub-tasks seed spec+api-contract include', () => {
+    // The verification parent carries no include; a blind inherit would
+    // leave fix-applier sub-tasks with empty injection. They MUST be seeded
+    // with spec + api-contract so the fix applier sees the contract.
+    const state = makeState();
+    const parent: CodeTask = {
+      id: 'final-v',
+      name: 'Final Verification',
+      type: 'verification',
+      priority: 1000,
+      description: '',
+    } as CodeTask;
+    const plan = JSON.stringify({
+      diagnostics: { totalErrors: 2 },
+      implementation: { modify: [] },
+      batches: [
+        { name: 'fix a', rationale: 'compile error in a', modify: ['a.ts'] },
+        { name: 'fix b', rationale: 'compile error in b', modify: ['b.ts'] },
+      ],
+    });
+
+    processDiagnosticBatchSplit(state, plan, parent);
+
+    const subs = state.taskQueue.getAll().filter((t: any) => t.type === 'error');
+    expect(subs.length).toBe(2);
+    for (const s of subs) {
+      expect((s as any).include).toEqual(['architecture/spec/', 'architecture/system/api-contract-']);
+    }
+  });
+
   it('non-feature sub-tasks (error parent → error children) MUST NOT carry band', () => {
     // Three-Axis SSOT: band is type-bound to FeatureCodeTask. Non-
     // feature sub-tasks must not surface a `band` field, even if the

--- a/packages/ant-shared/src/rac.ts
+++ b/packages/ant-shared/src/rac.ts
@@ -36,7 +36,7 @@ export interface InferWorkspaceState {
 // TechTier
 // ============================================
 
-import type { SupportedLanguage, TechTierKey } from './tech-tier-registry';
+import type { SupportedLanguage } from './tech-tier-registry';
 
 export type Language = SupportedLanguage;
 export type Stack = 'frontend' | 'backend' | 'fullstack';
@@ -340,67 +340,50 @@ export function buildTechTier(
 }
 
 // ============================================
-// PackageTier (per-package breakdown from decompose)
+// Per-task TechTier resolution (stack pointer → config slot)
 // ============================================
 
-export interface PackageTierEntry {
-  language: string;
-  framework?: string;
-  stack: string;
-}
-
 /**
- * Resolve task-level TechTiers from TechTierConfig + packageTiers mapping.
- * Returns TechTier[] for the task's packages, preserving per-package stack info.
- *
- * Rules:
+ * Resolve a single task's TechTier[] from its `stack` pointer + the job-level
+ * TechTierConfig. Task-level `stack` is always single (never fullstack):
  *  - No config → []
- *  - No packages or no mapping → all tiers from config
- *  - Package-based: lookup by stack key, deduplicate
+ *  - `stack` given → `[config[stack]]` (or [] if that slot is empty)
+ *  - `stack` omitted → the sole configured tier (`frontend ?? backend`). If the
+ *    config has BOTH (fullstack) while `stack` is omitted, that is an LLM
+ *    contract violation — warn and fall back to the first available tier.
  */
-export function resolveTaskTechTiersFromMap(
-  packages: string[] | undefined,
+export function resolveTaskTechTierFromStack(
+  stack: 'frontend' | 'backend' | undefined,
   techTierConfig: TechTierConfig | undefined,
-  packageTiers?: Record<string, PackageTierEntry>,
 ): TechTier[] {
   if (!techTierConfig) return [];
   const { frontend, backend } = techTierConfig;
-  const allTiers = [frontend, backend].filter((t): t is TechTier => !!t);
-  if (!packages?.length || !packageTiers || Object.keys(packageTiers).length === 0) {
-    return allTiers;
+
+  if (stack) {
+    const tier = techTierConfig[stack];
+    return tier ? [tier] : [];
   }
 
-  const VALID_KEYS: TechTierKey[] = ['frontend', 'backend'];
-  const seen = new Set<TechTierKey>();
-  const result: TechTier[] = [];
-  for (const pkg of packages) {
-    const entry = packageTiers[pkg];
-    if (!entry) continue;
-    const key = VALID_KEYS.find(k => k === entry.stack);
-    if (!key || seen.has(key)) continue;
-    seen.add(key);
-    const configTier = techTierConfig[key];
-    result.push({
-      language: (entry.language as Language) || configTier?.language,
-      framework: entry.framework || configTier?.framework,
-      stack: key,
-      packageManager: configTier?.packageManager,
-      gameEngine: configTier?.gameEngine,
-    });
+  if (frontend && backend) {
+    console.warn(
+      '⚠️ [TechTier] task.stack omitted but config has both frontend and backend; ' +
+      'defaulting to frontend (LLM must set task.stack on fullstack jobs).',
+    );
+    return [frontend];
   }
-  return result.length > 0 ? result : allTiers;
+  const sole = frontend ?? backend;
+  return sole ? [sole] : [];
 }
 
 /**
  * Apply explicit (preset) techTier overrides on top of resolved task tiers.
  *
  * Policy: explicit fields from `actionMetadata.basis.techTier` are authoritative
- * — they win over any value emitted by the LLM in `<techTier>` / `packageTiers`.
- * Mirrors the `visualTier` / `gameArtTier` / `gameContentTier` invariant.
+ * — they win over any value emitted by the LLM in `<techTier>`. Mirrors the
+ * `visualTier` / `gameArtTier` / `gameContentTier` invariant.
  *
  * Behavior:
- *  - `explicit` undefined → return input unchanged (infer path; preserves
- *    monorepo per-package divergence emitted via packageTiers).
+ *  - `explicit` undefined → return input unchanged (infer path).
  *  - For each task tier, if `explicit.{frontend|backend}` matches `tier.stack`,
  *    explicit fields (language / framework / packageManager / gameEngine) are
  *    merged onto the tier with explicit-first precedence.

--- a/packages/ant-shared/src/task.ts
+++ b/packages/ant-shared/src/task.ts
@@ -206,23 +206,22 @@ interface BaseTaskCommon {
   _failureReason?: string;
   timing?: TaskTiming;
   tokenUsage?: TaskTokenUsage;
-  packages?: string[];
+  /**
+   * Per-task tech-tier pointer. In a fullstack job each task targets exactly one
+   * runtime, so `stack` selects which `basis.techTier[stack]` slot resolves to
+   * `task.techTiers`. Single-stack jobs may omit it (the sole tier is used).
+   * Always single at task level (no fullstack value).
+   */
+  stack?: 'frontend' | 'backend';
   exclusive?: boolean;
   parallelGroup?: string;
   /**
-   * Artifact path prefix patterns for task-level document selection.
-   * When set, only artifacts matching these prefixes are injected into the prompt.
-   * When unset, taskType-based default rules apply (backward compatible).
+   * Single SSOT for per-task artifact injection. Artifact pool paths (or glob
+   * prefixes) selected into this task's plan/execute prompt. Authored by the
+   * decompose / revise LLM (RAC-validated) or seeded by task-creating helpers.
+   * Empty / unset ⇒ no artifacts pre-injected (explicit `[]`, not a default).
    */
   include?: string[];
-  /**
-   * Role-annotated artifact selection policy. When present, overrides `include`
-   * for role-aware selection via `selectArtifactsWithPolicy`.
-   */
-  artifactPolicy?: {
-    refs?: string[];
-    context?: string[];
-  };
   /**
    * Which UiSource feeds this task (only meaningful for UI-related task types:
    * 'ui' and 'design-system'). Kept BE-internal (routing + prompt dispatch only);

--- a/packages/ant-ui/src/domain/models/task.ts
+++ b/packages/ant-ui/src/domain/models/task.ts
@@ -36,8 +36,8 @@ export interface UnifiedTask {
   timing?: TaskTiming;
   tokenUsage?: TaskTokenUsage;
 
-  // Package scope
-  packages?: string[];
+  // Per-task tech-tier pointer (frontend / backend). Single at task level.
+  stack?: 'frontend' | 'backend';
 
   // Source files (design job)
   sourceFiles?: string[];
@@ -61,7 +61,7 @@ export function normalizeTask(task: Record<string, unknown>): UnifiedTask {
     _failureReason: task._failureReason as string | undefined,
     timing: task.timing as TaskTiming | undefined,
     tokenUsage: task.tokenUsage as TaskTokenUsage | undefined,
-    packages: Array.isArray(task.packages) ? task.packages as string[] : undefined,
+    stack: task.stack === 'frontend' || task.stack === 'backend' ? task.stack : undefined,
     sourceFiles: Array.isArray(task.sourceFiles) ? task.sourceFiles as string[] : undefined,
   };
 }

--- a/packages/ant-ui/src/presentation/components/TaskCard.tsx
+++ b/packages/ant-ui/src/presentation/components/TaskCard.tsx
@@ -385,28 +385,25 @@ export function TaskCard({
           </div>
         )}
 
-        {/* Meta row — packages / elapsed / token usage / expand chevron. */}
+        {/* Meta row — stack / elapsed / token usage / expand chevron. */}
         <div
           className="flex items-center flex-wrap gap-1.5 min-w-0"
           style={{ fontSize: 10, color: 'var(--text-4)' }}
         >
-          {task.packages && task.packages.length > 0 ? (
-            task.packages.map((p) => (
-              <span
-                key={p}
-                className="font-mono"
-                style={{
-                  padding: '1px 6px',
-                  borderRadius: '4px',
-                  background: 'var(--bg-surface-2)',
-                  color: 'var(--text-3)',
-                  fontWeight: 600,
-                  flexShrink: 0,
-                }}
-              >
-                {p}
-              </span>
-            ))
+          {task.stack ? (
+            <span
+              className="font-mono"
+              style={{
+                padding: '1px 6px',
+                borderRadius: '4px',
+                background: 'var(--bg-surface-2)',
+                color: 'var(--text-3)',
+                fontWeight: 600,
+                flexShrink: 0,
+              }}
+            >
+              {task.stack}
+            </span>
           ) : task.sourceFiles && task.sourceFiles.length > 0 ? (
             task.sourceFiles.map((f) => (
               <span


### PR DESCRIPTION
Collapse the overloaded per-task artifact-injection mechanisms into one LLM-authored, RAC-validated `task.include` field, and split per-task tech-tier into a `task.stack` pointer.

Removed (no dual-support / backward-compat):
- `deriveArtifactPolicy`, `selectArtifactsWithPolicy`, `flattenPolicyToInclude`, `getDesignDocByPackage(FromPool)`, `selectArtifacts` taskType default switch
- `task.packages` / `task.artifactPolicy` / `task.uiSections` fields
- `resolveTaskTechTiersFromMap` / `PackageTierEntry` / name-keyed `packageTiers`
- `targetFileToTag`
- explicit full-RAC bypass: `hasExplicitSelection` (execute/buildMessages), `hasExplicitDocs` (code plan/llm/prompt) — both pipelines now narrow identically

Added:
- `task.include` single injection SSOT; `selectArtifacts(pool, {include})` only
- `task.stack` + `resolveTaskTechTierFromStack(stack, config)`
- `<techTier>.{frontend,backend}` stack-keyed framework sub-objects (fullstack FE/BE frameworks never collapse to one value)
- `computeRacScope(resolvedAction)` in racGate.ts; RAC read-gate at the shared code `tool` node (gateCall -> orchestrator) covering plan + execute symmetrically
- batchSplit include carry-over: Path B inherits parent include; Path A (verification parent) seeds [SPEC, API_CONTRACT] for fix-applier sub-tasks

Updated prompts (decompose rules / techTier-rules / design-doc-guide / system-design rules / base / revise), ant-ui task model + TaskCard, docs (CLAUDE.md Post-RAC SSOT section, 14-code-job.md), and rewrote the affected test fixtures + added explicit-narrowing / fullstack-non-collapse / batchSplit-include regressions.

Verified: tsc clean (ant-cli/ant-shared/ant-ui); ant-cli 4292 pass +7 skip; ant-ui 408 pass; enforcement greps show 0 deleted-symbol residue in src.

<!--
Thanks for contributing to Ant!
Before opening this PR, please read CONTRIBUTING.md.
-->

## Summary

<!-- One or two sentences describing what this PR changes and why. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] CI / build / tooling

## Affected area

- [ ] `ant-cli` (backend / agents / LangGraph)
- [ ] `ant-ui` (frontend)
- [ ] `ant-shared` (cross-package types)
- [ ] Prompts / templates
- [ ] Docs (`docs/`)
- [ ] CI / build

## Test plan

<!--
How did you verify this works?

- Commands you ran (e.g. `pnpm test:cli`, `pnpm typecheck`).
- Manual scenarios you walked through.
- Screenshots or recordings for UI changes.
-->

## Linked issue

<!-- e.g. Closes #123 -->

## Checklist

- [ ] `pnpm build` succeeds locally (this also runs the tests).
- [ ] `pnpm typecheck` is clean.
- [ ] I added or updated tests when changing behaviour.
- [ ] I updated documentation (`docs/`, README, AGENTS.md) if my change affects users or contributors.
- [ ] No internal hostnames, incident codenames, or personal identifiers in this diff.
- [ ] If I touched prompts, I ran the relevant prompt-policy tests.
- [ ] Commit messages follow Conventional Commits (`feat: ...`, `fix: ...`).
